### PR TITLE
Fix/raftcreative rotation fixes

### DIFF
--- a/src/ValheimRAFT/ValheimRAFT.Patches/Character_Patch.cs
+++ b/src/ValheimRAFT/ValheimRAFT.Patches/Character_Patch.cs
@@ -95,4 +95,50 @@ public class Character_Patch
 
     if (!mbr && !bvc && __instance.transform.parent != null) __instance.transform.SetParent(null);
   }
+
+  /// <summary>
+  /// Fixes issue where player is running on a moving boat and then enters flying mode or hover mode if moving near edge and ship is moving forward but player is moving backwards
+  /// </summary>
+  /// <param name="__instance"></param>
+  /// <param name="collision"></param>
+  /// <returns></returns>
+  [HarmonyPatch(typeof(Character), "OnCollisionStay")]
+  [HarmonyPrefix]
+  private static bool OnCollisionStay(Character __instance, Collision collision)
+  {
+    if (!__instance.m_nview.IsValid() || !__instance.m_nview.IsOwner() ||
+        __instance.m_jumpTimer < 0.1f) return false;
+    var contacts = collision.contacts;
+    for (var i = 0; i < contacts.Length; i++)
+    {
+      var contactPoint = contacts[i];
+      var hitnormal = contactPoint.normal;
+      var hitpoint = contactPoint.point;
+      var hitDistance = Mathf.Abs(hitpoint.y - __instance.transform.position.y);
+      if (!__instance.m_groundContact && hitnormal.y < 0f && hitDistance < 0.1f)
+      {
+        hitnormal *= -1f;
+        hitpoint = __instance.transform.position;
+      }
+
+      if (!(hitnormal.y > 0.1f) || !(hitDistance < __instance.m_collider.radius)) continue;
+      if (hitnormal.y > __instance.m_groundContactNormal.y || !__instance.m_groundContact)
+      {
+        __instance.m_groundContact = true;
+        __instance.m_groundContactNormal = hitnormal;
+        __instance.m_groundContactPoint = hitpoint;
+        __instance.m_lowestContactCollider = collision.collider;
+        continue;
+      }
+
+      var groundContactNormal = Vector3.Normalize(__instance.m_groundContactNormal + hitnormal);
+      if (groundContactNormal.y > __instance.m_groundContactNormal.y)
+      {
+        __instance.m_groundContactNormal = groundContactNormal;
+        __instance.m_groundContactPoint = (__instance.m_groundContactPoint + hitpoint) * 0.5f;
+      }
+    }
+
+    return false;
+  }
 }

--- a/src/ValheimRAFT/ValheimRAFT.Patches/GamePause_Patch.cs
+++ b/src/ValheimRAFT/ValheimRAFT.Patches/GamePause_Patch.cs
@@ -23,8 +23,8 @@ public class GamePause_Patch
     // not on ship, do nothing
     if (!baseVehicleShip) return;
 
-    var hasPeerConnections = ZNet.instance?.GetPeerConnections() > 0;
-
+    var hasPeerConnections = ZNet.instance?.GetPeerConnections() > 0 ||
+                             ValheimRaftPlugin.Instance.ShipPausePatchSinglePlayer.Value;
     // Previously onPause the time was set to 0 regarless if using multiplayer, which borks ZDOs and Physics updates that are reliant on the controlling player.
     // Also causes issues with Players that are on a ship controlled by another player and the ship moves out of range. The player is forced through the wall or smashed up into the air.
     if (Game.IsPaused())

--- a/src/ValheimRAFT/ValheimRAFT/CreativeModeConsoleCommand.cs
+++ b/src/ValheimRAFT/ValheimRAFT/CreativeModeConsoleCommand.cs
@@ -90,7 +90,7 @@ public class CreativeModeConsoleCommand : ConsoleCommand
         character.m_body.isKinematic = true;
         character.m_body.position = new Vector3(
           character.m_body.transform.position.x,
-          character.m_body.transform.position.y + 1f +
+          character.m_body.transform.position.y + 0.2f +
           ValheimRaftPlugin.Instance.RaftCreativeHeight.Value,
           character.m_body.transform.position.z);
 

--- a/src/ValheimRAFT/ValheimRAFT/CreativeModeConsoleCommand.cs
+++ b/src/ValheimRAFT/ValheimRAFT/CreativeModeConsoleCommand.cs
@@ -68,15 +68,15 @@ public class CreativeModeConsoleCommand : ConsoleCommand
     {
       var shipYPosition =
         ship.m_body.position.y + ValheimRaftPlugin.Instance.RaftCreativeHeight.Value;
-      if (player.transform.parent == ship.VehicleController.Instance.transform)
+      var playerInBoat = player.transform.parent == ship.VehicleController.Instance.transform;
+      if (playerInBoat)
       {
         player.m_body.isKinematic = true;
         player.m_body.position = new Vector3(
           player.m_body.transform.position.x,
-          player.m_body.transform.position.y + 2f +
+          player.m_body.transform.position.y + 1f +
           ValheimRaftPlugin.Instance.RaftCreativeHeight.Value,
           player.m_body.transform.position.z);
-
         // prevents player from being launched into the sky if the ship hits them when it is moved upwards
       }
 
@@ -91,6 +91,11 @@ public class CreativeModeConsoleCommand : ConsoleCommand
       ship.Instance.transform.rotation = rotationWithoutTilt;
       ship.VehicleController.Instance.transform.rotation = rotationWithoutTilt;
       ship.transform.rotation = rotationWithoutTilt;
+
+      if (playerInBoat)
+      {
+        player.m_body.isKinematic = false;
+      }
     }
     else
     {

--- a/src/ValheimRAFT/ValheimRAFT/CreativeModeConsoleCommand.cs
+++ b/src/ValheimRAFT/ValheimRAFT/CreativeModeConsoleCommand.cs
@@ -66,8 +66,11 @@ public class CreativeModeConsoleCommand : ConsoleCommand
 
     if (toggledKinematicValue)
     {
+      var shipYPosition =
+        ship.m_body.position.y + ValheimRaftPlugin.Instance.RaftCreativeHeight.Value;
       if (player.transform.parent == ship.VehicleController.Instance.transform)
       {
+        player.m_body.isKinematic = true;
         player.m_body.position = new Vector3(
           player.m_body.transform.position.x,
           player.m_body.transform.position.y + 2f +
@@ -75,13 +78,12 @@ public class CreativeModeConsoleCommand : ConsoleCommand
           player.m_body.transform.position.z);
 
         // prevents player from being launched into the sky if the ship hits them when it is moved upwards
-        player.m_body.isKinematic = true;
       }
 
       var directionRaftUpwards = new Vector3(ship.transform.position.x,
-        ship.m_body.position.y + ValheimRaftPlugin.Instance.RaftCreativeHeight.Value,
+        shipYPosition,
         ship.transform.position.z);
-      var rotationWithoutTilt = Quaternion.Euler(0f, ship.m_body.rotation.eulerAngles.y, 0f);
+      var rotationWithoutTilt = Quaternion.Euler(0, ship.m_body.rotation.eulerAngles.y, 0);
       ship.SetCreativeMode(true);
 
       ship.m_body.position = directionRaftUpwards;
@@ -89,9 +91,6 @@ public class CreativeModeConsoleCommand : ConsoleCommand
       ship.Instance.transform.rotation = rotationWithoutTilt;
       ship.VehicleController.Instance.transform.rotation = rotationWithoutTilt;
       ship.transform.rotation = rotationWithoutTilt;
-
-      // set player back to being controllable
-      player.m_body.isKinematic = false;
     }
     else
     {

--- a/src/ValheimRAFT/ValheimRAFT/CreativeModeConsoleCommand.cs
+++ b/src/ValheimRAFT/ValheimRAFT/CreativeModeConsoleCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Jotunn.Entities;
 using UnityEngine;
 using ValheimVehicles.Vehicles;
@@ -14,6 +15,14 @@ public class CreativeModeConsoleCommand : ConsoleCommand
   public override void Run(string[] args)
   {
     RunCreativeModeCommand(Name);
+  }
+
+  private static IEnumerator SetPlayerBackOnBoat(Character character)
+  {
+    yield return new WaitForFixedUpdate();
+    character.m_body.velocity = Vector3.zero;
+    character.m_body.angularVelocity = Vector3.zero;
+    character.m_body.isKinematic = false;
   }
 
   public static void RunCreativeModeCommand(string comandName)
@@ -52,7 +61,14 @@ public class CreativeModeConsoleCommand : ConsoleCommand
     }
   }
 
-  private static bool ToggleMode(Character player,
+  /// <summary>
+  /// This moves the ship in the air for ship creation
+  /// </summary>
+  /// todo move all rigidbodies near or on the ship into a non-collision state and then move them back to the ship with the offset. This way this prevents all rigidbodies from being smashed into air
+  /// <param name="character"></param>
+  /// <param name="ship"></param>
+  /// <returns></returns>
+  private static bool ToggleMode(Character character,
     VehicleShip ship)
   {
     if (!(bool)ship)
@@ -68,15 +84,16 @@ public class CreativeModeConsoleCommand : ConsoleCommand
     {
       var shipYPosition =
         ship.m_body.position.y + ValheimRaftPlugin.Instance.RaftCreativeHeight.Value;
-      var playerInBoat = player.transform.parent == ship.VehicleController.Instance.transform;
+      var playerInBoat = character.transform.parent == ship.VehicleController.Instance.transform;
       if (playerInBoat)
       {
-        player.m_body.isKinematic = true;
-        player.m_body.position = new Vector3(
-          player.m_body.transform.position.x,
-          player.m_body.transform.position.y + 1f +
+        character.m_body.isKinematic = true;
+        character.m_body.position = new Vector3(
+          character.m_body.transform.position.x,
+          character.m_body.transform.position.y + 1f +
           ValheimRaftPlugin.Instance.RaftCreativeHeight.Value,
-          player.m_body.transform.position.z);
+          character.m_body.transform.position.z);
+
         // prevents player from being launched into the sky if the ship hits them when it is moved upwards
       }
 
@@ -91,11 +108,7 @@ public class CreativeModeConsoleCommand : ConsoleCommand
       ship.Instance.transform.rotation = rotationWithoutTilt;
       ship.VehicleController.Instance.transform.rotation = rotationWithoutTilt;
       ship.transform.rotation = rotationWithoutTilt;
-
-      if (playerInBoat)
-      {
-        player.m_body.isKinematic = false;
-      }
+      character.StartCoroutine(SetPlayerBackOnBoat(character));
     }
     else
     {
@@ -106,7 +119,7 @@ public class CreativeModeConsoleCommand : ConsoleCommand
     return true;
   }
 
-  private static bool ToggleMode(Player player, Ship ship)
+  private static bool ToggleMode(Player character, Ship ship)
   {
     var mb = ship.GetComponent<MoveableBaseShipComponent>();
     if ((bool)mb)
@@ -116,13 +129,13 @@ public class CreativeModeConsoleCommand : ConsoleCommand
       zsync.m_isKinematicBody = mb.m_rigidbody.isKinematic;
       if (mb.m_rigidbody.isKinematic)
       {
-        if (player.transform.parent == mb.m_baseRoot.transform)
+        if (character.transform.parent == mb.m_baseRoot.transform)
         {
-          player.m_body.position = new Vector3(
-            player.m_body.transform.position.x,
-            player.m_body.transform.position.y +
+          character.m_body.position = new Vector3(
+            character.m_body.transform.position.x,
+            character.m_body.transform.position.y +
             ValheimRaftPlugin.Instance.RaftCreativeHeight.Value,
-            player.m_body.transform.position.z);
+            character.m_body.transform.position.z);
         }
 
         mb.m_rigidbody.position =
@@ -130,7 +143,7 @@ public class CreativeModeConsoleCommand : ConsoleCommand
             mb.m_rigidbody.position.y + ValheimRaftPlugin.Instance.RaftCreativeHeight.Value,
             mb.transform.position.z);
         mb.m_rigidbody.transform.rotation =
-          Quaternion.Euler(0f, mb.m_rigidbody.rotation.eulerAngles.y, 0f);
+          Quaternion.Euler(0, mb.m_rigidbody.rotation.eulerAngles.y, 0);
         mb.isCreative = true;
       }
       else

--- a/src/ValheimRAFT/ValheimRAFT/ValheimRaftPlugin.cs
+++ b/src/ValheimRAFT/ValheimRAFT/ValheimRaftPlugin.cs
@@ -63,6 +63,7 @@ public class ValheimRaftPlugin : BaseUnityPlugin
   public ConfigEntry<bool> PlanBuildPatches { get; set; }
 
   public ConfigEntry<bool> ShipPausePatch { get; set; }
+  public ConfigEntry<bool> ShipPausePatchSinglePlayer { get; set; }
 
 
   public ConfigEntry<float> ServerRaftUpdateZoneInterval { get; set; }
@@ -390,6 +391,11 @@ public class ValheimRaftPlugin : BaseUnityPlugin
       "Vehicles Prevent Pausing", true,
       CreateConfigDescription(
         "Prevents pausing on a boat, pausing causes a TON of desync problems and can make your boat crash or other players crash",
+        true, true));
+    ShipPausePatchSinglePlayer = Config.Bind<bool>("Patches",
+      "Vehicles Prevent Pausing SinglePlayer", true,
+      CreateConfigDescription(
+        "Prevents pausing on a boat during singleplayer. Must have the Vehicle Prevent Pausing patch as well",
         true, true));
     PlanBuildPatches = Config.Bind<bool>("Patches",
       "Enable PlanBuild Patches (required to be on if you installed PlanBuild)", false,

--- a/src/ValheimVehicles/ValheimVehicles.ConsoleCommands/VehicleCommands.cs
+++ b/src/ValheimVehicles/ValheimVehicles.ConsoleCommands/VehicleCommands.cs
@@ -56,7 +56,10 @@ public class VehicleCommands : ConsoleCommand
   {
     var firstArg = args.First();
     if (firstArg == null)
+    {
+      Logger.LogMessage("Must provide a argument for `vehicle` command");
       return;
+    }
 
     switch (firstArg)
     {
@@ -64,7 +67,7 @@ public class VehicleCommands : ConsoleCommand
       //   LocateVehicle.LocateAllVehicles();
       //   break;
       case VehicleCommandArgs.move:
-        VehicleMove();
+        VehicleMove(args);
         break;
       case VehicleCommandArgs.stopOceanSway:
         VehicleStopOceanSway();

--- a/src/ValheimVehicles/ValheimVehicles.ConsoleCommands/VehicleCommands.cs
+++ b/src/ValheimVehicles/ValheimVehicles.ConsoleCommands/VehicleCommands.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using BepInEx.Logging;
@@ -5,10 +6,12 @@ using Components;
 using Jotunn.Entities;
 using Jotunn.Managers;
 using UnityEngine;
+using UnityEngine.Assertions.Must;
 using ValheimRAFT;
 using ValheimVehicles.Prefabs;
 using ValheimVehicles.Vehicles;
 using Logger = Jotunn.Logger;
+using Object = UnityEngine.Object;
 
 namespace ValheimVehicles.ConsoleCommands;
 
@@ -24,25 +27,24 @@ public class VehicleCommands : ConsoleCommand
     public const string creative = "creative";
     public const string help = "help";
     public const string recover = "recover";
+    public const string rotate = "rotate";
+    public const string move = "move";
+    public const string stopOceanSway = "stopOceanSway";
     public const string upgradeToV2 = "upgradeShipToV2";
     public const string downgradeToV1 = "downgradeShipToV1";
   }
 
   public override string Help => OnHelp();
 
-  public string OnHelp()
+  public static string OnHelp()
   {
     return
       "Runs vehicle commands, each command will require parameters to run use help to see the input values." +
-      "\n<debug> will show a menu with options like rotating or debugging vehicle colliders" +
-      "\n<recover>: will recover any vehicles within range of 1000 and turn them into V2 Vehicles";
-  }
-
-  private class RotateArgs
-  {
-    public const string rotateX = "x";
-    public const string rotateY = "y";
-    public const string rotateZ = "z";
+      "\n<debug>: will show a menu with options like rotating or debugging vehicle colliders" +
+      "\n<recover>: will recover any vehicles within range of 1000 and turn them into V2 Vehicles" +
+      "\n<rotate>: defaults to zeroing x and z tilt. Can also provide 3 args: x y z" +
+      "\n<move>: Must provide 3 args: x y z, the movement is relative to those points" +
+      "\n<stopOceanSway>: stops the vehicle from swaying in the water. It will stay at 0 degrees (x and z) tilt and only allow rotating on y axis";
   }
 
   public override void Run(string[] args)
@@ -61,6 +63,15 @@ public class VehicleCommands : ConsoleCommand
       // case VehicleCommandArgs.locate:
       //   LocateVehicle.LocateAllVehicles();
       //   break;
+      case VehicleCommandArgs.move:
+        VehicleMove();
+        break;
+      case VehicleCommandArgs.stopOceanSway:
+        VehicleStopOceanSway();
+        break;
+      case VehicleCommandArgs.rotate:
+        VehicleRotate(args);
+        break;
       case VehicleCommandArgs.recover:
         RecoverRaftConsoleCommand.RecoverRaftWithoutDryRun($"{Name} {VehicleCommandArgs.recover}");
         break;
@@ -76,6 +87,73 @@ public class VehicleCommands : ConsoleCommand
       case VehicleCommandArgs.downgradeToV1:
         RunDowngradeToV1();
         break;
+    }
+  }
+
+  public void VehicleMove(string[] args)
+  {
+    var vehicleController = VehicleDebugHelpers.GetVehicleController();
+    if (vehicleController == null)
+    {
+      Logger.LogMessage("No VehicleController Detected");
+      return;
+    }
+
+    if (args.Length == 4)
+    {
+      float.TryParse(args[1], out var x);
+      float.TryParse(args[2], out var y);
+      float.TryParse(args[3], out var z);
+      var offsetVector = new Vector3(x, y, z);
+      vehicleController.VehicleInstance.Instance.transform.position += offsetVector;
+    }
+    else
+    {
+      Logger.LogMessage("Must provide x y z parameters, IE: vehicle rotate 0.5 0 10");
+    }
+  }
+
+  /// <summary>
+  /// Freezes the Vehicle rotation permenantly until the boat is unloaded similar to raftcreative 
+  /// </summary>
+  private static void VehicleStopOceanSway()
+  {
+    var vehicleController = VehicleDebugHelpers.GetVehicleController();
+    if (!vehicleController)
+    {
+      Logger.LogMessage("No VehicleController Detected");
+      return;
+    }
+
+    vehicleController?.VehicleInstance.Instance.MovementController.SendToggleOceanSway();
+  }
+
+  private static void VehicleRotate(string[] args)
+  {
+    var vehicleController = VehicleDebugHelpers.GetVehicleController();
+    if (!vehicleController)
+    {
+      Logger.LogMessage("No VehicleController Detected");
+      return;
+    }
+
+    if (args.Length == 1)
+    {
+      vehicleController.VehicleInstance.Instance.FixShipRotation();
+    }
+
+    if (args.Length == 4)
+    {
+      float.TryParse(args[1], out var x);
+      float.TryParse(args[2], out var y);
+      float.TryParse(args[3], out var z);
+      vehicleController.VehicleInstance.Instance.transform.rotation = Quaternion.Euler(
+        Mathf.Approximately(0f, x) ? 0 : x, Mathf.Approximately(0f, y) ? 0 : y,
+        Mathf.Approximately(0f, z) ? 0 : z);
+    }
+    else
+    {
+      Logger.LogMessage("Must provide x y z parameters, IE: vehicle rotate 0.5 0 10");
     }
   }
 
@@ -150,6 +228,8 @@ public class VehicleCommands : ConsoleCommand
   [
     // VehicleCommandArgs.locate, 
     // VehicleCommandArgs.destroy,
+    VehicleCommandArgs.rotate,
+    VehicleCommandArgs.stopOceanSway,
     VehicleCommandArgs.creative,
     VehicleCommandArgs.debug,
     VehicleCommandArgs.help,

--- a/src/ValheimVehicles/ValheimVehicles.ConsoleCommands/VehicleCommands.cs
+++ b/src/ValheimVehicles/ValheimVehicles.ConsoleCommands/VehicleCommands.cs
@@ -29,7 +29,7 @@ public class VehicleCommands : ConsoleCommand
     public const string recover = "recover";
     public const string rotate = "rotate";
     public const string move = "move";
-    public const string stopOceanSway = "stopOceanSway";
+    public const string toggleOceanSway = "toggleOceanSway";
     public const string upgradeToV2 = "upgradeShipToV2";
     public const string downgradeToV1 = "downgradeShipToV1";
   }
@@ -40,11 +40,11 @@ public class VehicleCommands : ConsoleCommand
   {
     return
       "Runs vehicle commands, each command will require parameters to run use help to see the input values." +
-      "\n<debug>: will show a menu with options like rotating or debugging vehicle colliders" +
-      "\n<recover>: will recover any vehicles within range of 1000 and turn them into V2 Vehicles" +
-      "\n<rotate>: defaults to zeroing x and z tilt. Can also provide 3 args: x y z" +
-      "\n<move>: Must provide 3 args: x y z, the movement is relative to those points" +
-      "\n<stopOceanSway>: stops the vehicle from swaying in the water. It will stay at 0 degrees (x and z) tilt and only allow rotating on y axis";
+      $"\n<{VehicleCommandArgs.debug}>: will show a menu with options like rotating or debugging vehicle colliders" +
+      $"\n<{VehicleCommandArgs.recover}>: will recover any vehicles within range of 1000 and turn them into V2 Vehicles" +
+      $"\n<{VehicleCommandArgs.rotate}>: defaults to zeroing x and z tilt. Can also provide 3 args: x y z" +
+      $"\n<{VehicleCommandArgs.move}>: Must provide 3 args: x y z, the movement is relative to those points" +
+      $"\n<{VehicleCommandArgs.toggleOceanSway}>: stops the vehicle from swaying in the water. It will stay at 0 degrees (x and z) tilt and only allow rotating on y axis";
   }
 
   public override void Run(string[] args)
@@ -69,7 +69,7 @@ public class VehicleCommands : ConsoleCommand
       case VehicleCommandArgs.move:
         VehicleMove(args);
         break;
-      case VehicleCommandArgs.stopOceanSway:
+      case VehicleCommandArgs.toggleOceanSway:
         VehicleStopOceanSway();
         break;
       case VehicleCommandArgs.rotate:
@@ -232,7 +232,7 @@ public class VehicleCommands : ConsoleCommand
     // VehicleCommandArgs.locate, 
     // VehicleCommandArgs.destroy,
     VehicleCommandArgs.rotate,
-    VehicleCommandArgs.stopOceanSway,
+    VehicleCommandArgs.toggleOceanSway,
     VehicleCommandArgs.creative,
     VehicleCommandArgs.debug,
     VehicleCommandArgs.help,

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/VehicleMovementController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/VehicleMovementController.cs
@@ -84,6 +84,7 @@ public class VehicleMovementController : MonoBehaviour, IVehicleMovement
     }
 
     InitializeRPC();
+    SyncShip();
   }
 
   public Ship.Speed GetSpeedSetting() => vehicleSpeed;

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/VehicleMovementController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/VehicleMovementController.cs
@@ -217,9 +217,23 @@ public class VehicleMovementController : MonoBehaviour, IVehicleMovement
 
   private void UnRegisterRPCListeners()
   {
+    // ship speed
+    NetView.Unregister(nameof(RPC_SpeedChange));
+
+    // anchor logic
+    NetView.Unregister(nameof(RPC_SetAnchor));
+
+    // rudder direction
+    NetView.Unregister(nameof(RPC_Rudder));
+
+    // boat sway
+    NetView.Unregister(nameof(RPC_SetOceanSway));
+
+    // steering
     NetView.Unregister(nameof(RPC_RequestControl));
     NetView.Unregister(nameof(RPC_RequestResponse));
     NetView.Unregister(nameof(RPC_ReleaseControl));
+
     _hasRegister = false;
   }
 
@@ -227,10 +241,13 @@ public class VehicleMovementController : MonoBehaviour, IVehicleMovement
   {
     // ship speed
     NetView.Register<int>(nameof(RPC_SpeedChange), RPC_SpeedChange);
+
     // anchor logic
     NetView.Register<bool>(nameof(RPC_SetAnchor), RPC_SetAnchor);
+
     // rudder direction
     NetView.Register<float>(nameof(RPC_Rudder), RPC_Rudder);
+
     // boat sway
     NetView.Register<bool>(nameof(RPC_SetOceanSway), RPC_SetOceanSway);
 

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/VehicleShip.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/VehicleShip.cs
@@ -455,18 +455,6 @@ public class VehicleShip : ValheimBaseGameShip, IValheimShip, IVehicleShip
     }
   }
 
-  public void ToggleBoatOceanSway(bool val)
-  {
-    _hasBoatSway = val;
-    m_body.isKinematic = !val;
-    if (!_hasBoatSway)
-    {
-      m_body.velocity = Vector3.zero;
-      m_body.angularVelocity = Vector3.zero;
-      transform.rotation = Quaternion.Euler(0, transform.rotation.y, 0);
-    }
-  }
-
   public void UpdateShipZdoPosition()
   {
     if (!(bool)m_nview || m_nview.GetZDO() == null || m_nview.m_ghost || (bool)_controller ||
@@ -862,6 +850,11 @@ public class VehicleShip : ValheimBaseGameShip, IValheimShip, IVehicleShip
     UpdateVehicleStats(false);
     UpdateWaterForce(shipFloatation);
     ApplyEdgeForce(Time.fixedDeltaTime);
+    if (MovementController.HasOceanSwayDisabled)
+    {
+      transform.rotation = Quaternion.Euler(0, transform.rotation.eulerAngles.y, 0);
+    }
+
     if (UpdateAnchorVelocity(m_body.velocity)) return;
 
     ApplySailForce(this);

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/VehicleZdoVars.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/VehicleZdoVars.cs
@@ -4,4 +4,5 @@ public static class VehicleZdoVars
 {
   public static readonly int VehicleFlags = "VehicleFlags".GetStableHashCode();
   public static readonly int VehicleTargetHeight = "VehicleTargetHeight".GetStableHashCode();
+  public static readonly int VehicleOceanSway = "VehicleOceanSway".GetStableHashCode();
 }


### PR DESCRIPTION
- fixes floating player issue after removing a collision logic item that looked unnecessary 🫤 
- add a bunch of helpful commands
- `vehicle rotate` moves the vehicle based on `x y z` or defaults to just fixing rotation on X and Z axis (sets to 0). (may need to set rigidbody to kinematic) 
- `vehicle toggleOceanSway` permanently disable sway. (and turn on again)
- `vehicle move` moves the vehicle based on `x y z` (requires kinematic toggle) 
- creative now properly rotates I was using floats for 0. `0 != 0f`