### PR TITLE
set all raft positions to the center of the vehicle bounds

### DIFF
--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
@@ -463,8 +463,12 @@ public class VehiclePiecesController : MonoBehaviour
       }
 
       piece.transform.SetParent(null);
+      piece.GetZDO()?.SetPosition(_vehicleBounds.center);
       AddInactivePiece(VehicleInstance!.PersistentZdoId, piece, null);
     }
+
+    // sets vehicle to center so on regeneration all pieces will be spawning around the center instead of the raftball being far away from the actual pieces
+    VehicleInstance?.NetView?.GetZDO()?.SetPosition(_vehicleBounds.center);
 
     StopAllCoroutines();
   }
@@ -590,15 +594,17 @@ public class VehiclePiecesController : MonoBehaviour
         nv.GetZDO().SetSector(currentPieceControllerSector);
       }
 
+      var positionFromCenterBounds = transform.position + _vehicleBounds.center;
+
       if (zdo != null && currentPieceControllerSector != zdo?.GetSector())
       {
         nv.m_zdo?.SetPosition(transform.position);
-        VehicleInstance?.NetView?.m_zdo.SetPosition(transform.position);
+        VehicleInstance?.NetView?.m_zdo.SetPosition(positionFromCenterBounds);
       }
 
       if (transform.position != nv.transform.position)
       {
-        nv.m_zdo?.SetPosition(transform.position);
+        nv.m_zdo?.SetPosition(positionFromCenterBounds);
       }
     }
   }
@@ -652,8 +658,9 @@ public class VehiclePiecesController : MonoBehaviour
 
   public void UpdatePieces(List<ZDO> list)
   {
-    var pos = transform.position;
-    var sector = ZoneSystem.instance.GetZone(pos);
+    // var pos = transform.position;
+    var positionFromCenterBounds = transform.position + _vehicleBounds.center;
+    var sector = ZoneSystem.instance.GetZone(positionFromCenterBounds);
 
     if (m_serverSector == sector) return;
     if (!sector.Equals(m_sector)) m_sector = sector;
@@ -675,7 +682,7 @@ public class VehiclePiecesController : MonoBehaviour
         continue;
       }
 
-      zdo.SetPosition(pos);
+      zdo.SetPosition(positionFromCenterBounds);
     }
   }
 


### PR DESCRIPTION
Resolve #109. Likely fixes a bunch of annoyances with the raft ball spawning underground or in places it shouldnt be. 