### PR TITLE
Feat/ladder and minor tweaks

### DIFF
--- a/src/ValheimRAFT/ValheimRAFT.Patches/Character_Patch.cs
+++ b/src/ValheimRAFT/ValheimRAFT.Patches/Character_Patch.cs
@@ -36,7 +36,7 @@ public class Character_Patch
   public static void Character_IsInWater(Character __instance,
     ref bool __result)
   {
-    var vpc = __instance.transform.root.GetComponent<VehiclePiecesController>();
+    var vpc = WaterZoneUtils.IsOnboard(__instance);
     if (vpc) __result = false;
     // var isOnboard = WaterZoneUtils.IsOnboard(__instance);
     // if (isOnboard) __result = false;

--- a/src/ValheimRAFT/ValheimRAFT.Patches/PlanBuild_Patch.cs
+++ b/src/ValheimRAFT/ValheimRAFT.Patches/PlanBuild_Patch.cs
@@ -17,14 +17,14 @@ public class PlanBuild_Patch
 {
   [HarmonyPatch(typeof(PlanPiece), "CalculateSupported")]
   [HarmonyPrefix]
-  private static bool PlanPiece_CalculateSupported_Prefix(PlanPiece __instance, ref bool __result)
+  private static bool PlanPiece_CalculateSupported_Prefix(PlanPiece __instance,
+    ref bool __result)
   {
     if (__instance.GetComponentInParent<VehiclePiecesController>())
     {
       __result = true;
       return false;
     }
-
 
     if (__instance.GetComponentInParent<MoveableBaseRootComponent>())
     {
@@ -37,10 +37,12 @@ public class PlanBuild_Patch
 
   [HarmonyPatch(typeof(PlanPiece), "OnPieceReplaced")]
   [HarmonyPrefix]
-  private static void PlanPiece_OnPieceReplaced_Postfix(GameObject originatingPiece,
+  private static void PlanPiece_OnPieceReplaced_Postfix(
+    GameObject originatingPiece,
     GameObject placedPiece)
   {
-    var baseVehicle = originatingPiece.GetComponentInParent<VehiclePiecesController>();
+    var baseVehicle =
+      originatingPiece.GetComponentInParent<VehiclePiecesController>();
 
     if (baseVehicle)
     {
@@ -48,7 +50,8 @@ public class PlanBuild_Patch
       return;
     }
 
-    var moveableBaseRoot = originatingPiece.GetComponentInParent<MoveableBaseRootComponent>();
+    var moveableBaseRoot =
+      originatingPiece.GetComponentInParent<MoveableBaseRootComponent>();
     if (moveableBaseRoot)
     {
       moveableBaseRoot.AddNewPiece(placedPiece.GetComponent<Piece>());
@@ -57,7 +60,8 @@ public class PlanBuild_Patch
 
   [HarmonyPatch(typeof(PlacementComponent), "OnPiecePlaced")]
   [HarmonyPrefix]
-  private static void BlueprintManager_OnPiecePlaced_Postfix(GameObject placedPiece)
+  private static void BlueprintManager_OnPiecePlaced_Postfix(
+    GameObject placedPiece)
   {
     Player_Patch.PlacedPiece(placedPiece);
     // ValheimRAFT_Patch.PlacedPiece(Player.m_localPlayer, placedPiece);
@@ -66,7 +70,8 @@ public class PlanBuild_Patch
 
   [HarmonyPatch(typeof(Blueprint), "Capture")]
   [HarmonyPrefix]
-  public static bool Capture(Blueprint __instance, ref bool __result, Selection selection,
+  public static bool Capture(Blueprint __instance, ref bool __result,
+    Selection selection,
     bool captureCurrentSnapPoints = false, bool keepMarkers = false)
   {
     Logger.LogDebug("Using ValheimRAFT patch for: PlanBuild.Blueprint.Capture");
@@ -80,7 +85,8 @@ public class PlanBuild_Patch
     >();
     foreach (ZDOID item2 in selection)
     {
-      GameObject gameObject = BlueprintManager.GetGameObject(item2, required: true);
+      GameObject gameObject =
+        BlueprintManager.GetGameObject(item2, required: true);
       Logger.LogDebug($"GameObject {gameObject.name}");
       if (gameObject.name.StartsWith("piece_bpsnappoint"))
       {
@@ -137,7 +143,8 @@ public class PlanBuild_Patch
       Piece component4 = gameObject.GetComponent<Piece>();
       if (!BlueprintManager.CanCapture(component4))
       {
-        Jotunn.Logger.LogWarning($"Ignoring piece {component4}, not able to make blueprint");
+        Jotunn.Logger.LogWarning(
+          $"Ignoring piece {component4}, not able to make blueprint");
         continue;
       }
 
@@ -190,7 +197,8 @@ public class PlanBuild_Patch
     }
 
     IOrderedEnumerable<Piece> orderedEnumerable = from x in list
-      orderby x.transform.position.y, x.transform.position.x, x.transform.position.z
+      orderby x.transform.position.y, x.transform.position.x, x.transform
+        .position.z
       select x;
     int num5 = orderedEnumerable.Count();
     if (__instance.PieceEntries == null)
@@ -199,7 +207,8 @@ public class PlanBuild_Patch
     }
     else if (__instance.PieceEntries.Length != 0)
     {
-      Array.Clear(__instance.PieceEntries, 0, __instance.PieceEntries.Length - 1);
+      Array.Clear(__instance.PieceEntries, 0,
+        __instance.PieceEntries.Length - 1);
       Array.Resize(ref __instance.PieceEntries, num5);
     }
 
@@ -207,8 +216,10 @@ public class PlanBuild_Patch
     foreach (Piece item4 in orderedEnumerable)
     {
       Vector3 pos;
-      var shipBase = item4.m_nview.GetComponentInParent<MoveableBaseRootComponent>();
-      var vehicleBase = item4.m_nview.GetComponentInParent<VehiclePiecesController>();
+      var shipBase =
+        item4.m_nview.GetComponentInParent<MoveableBaseRootComponent>();
+      var vehicleBase =
+        item4.m_nview.GetComponentInParent<VehiclePiecesController>();
       if (shipBase)
       {
         Logger.LogDebug(
@@ -257,10 +268,13 @@ public class PlanBuild_Patch
       }
 
       ItemStand component6 = item4.GetComponent<ItemStand>();
-      if (component6 != null && component6.HaveAttachment() && (bool)component6.m_nview)
+      if (component6 != null && component6.HaveAttachment() &&
+          (bool)component6.m_nview)
       {
-        text = string.Format("{0}:{1}:{2}", component6.m_nview.m_zdo.GetString("item"),
-          component6.m_nview.m_zdo.GetInt("variant"), component6.m_nview.m_zdo.GetInt("quality"));
+        text = string.Format("{0}:{1}:{2}",
+          component6.m_nview.m_zdo.GetString("item"),
+          component6.m_nview.m_zdo.GetInt("variant"),
+          component6.m_nview.m_zdo.GetInt("quality"));
       }
 
       ArmorStand component7 = item4.GetComponent<ArmorStand>();
@@ -283,7 +297,8 @@ public class PlanBuild_Patch
       PrivateArea component9 = item4.GetComponent<PrivateArea>();
       if (component9 != null && (bool)component9.m_nview)
       {
-        text = string.Format("{0}", component9.m_nview.m_zdo.GetBool("enabled"));
+        text = string.Format("{0}",
+          component9.m_nview.m_zdo.GetBool("enabled"));
       }
 
       Container component10 = item4.GetComponent<Container>();
@@ -297,7 +312,8 @@ public class PlanBuild_Patch
       ZNetView component11 = item4.gameObject.GetComponent<ZNetView>();
       if ((object)component11 != null && component11.m_zdo != null)
       {
-        GameObject prefab = ZNetScene.instance.GetPrefab(component11.m_zdo.m_prefab);
+        GameObject prefab =
+          ZNetScene.instance.GetPrefab(component11.m_zdo.m_prefab);
         if ((object)prefab != null)
         {
           text2 = prefab.name;
@@ -309,7 +325,8 @@ public class PlanBuild_Patch
         text2 = text2.Replace("_planned", null);
       }
 
-      __instance.PieceEntries[num6++] = new PieceEntry(text2, item4.m_category.ToString(), pos,
+      __instance.PieceEntries[num6++] = new PieceEntry(text2,
+        item4.m_category.ToString(), pos,
         rotation, text, localScale);
     }
 
@@ -347,7 +364,8 @@ public class PlanBuild_Patch
     foreach (TerrainModEntry item5 in list3)
     {
       __instance.TerrainMods[num7++] = new TerrainModEntry(item5.shape,
-        item5.GetPosition() - vector, item5.radius, item5.rotation, item5.smooth, item5.paint);
+        item5.GetPosition() - vector, item5.radius, item5.rotation,
+        item5.smooth, item5.paint);
     }
 
     __result = true;

--- a/src/ValheimRAFT/ValheimRAFT.Patches/Player_Patch.cs
+++ b/src/ValheimRAFT/ValheimRAFT.Patches/Player_Patch.cs
@@ -17,8 +17,13 @@ namespace ValheimRAFT.Patches;
 
 public class Player_Patch
 {
+  /// <summary>
+  /// TODO may need to add a TryPlacePiece patch to override if blocked by water on boat.
+  /// </summary>
+  /// <param name="instructions"></param>
+  /// <returns></returns>
   [HarmonyTranspiler]
-  [HarmonyPatch(typeof(Player), "PlacePiece")]
+  [HarmonyPatch(typeof(Player), nameof(Player.PlacePiece))]
   private static IEnumerable<CodeInstruction> PlacePieceTranspiler(
     IEnumerable<CodeInstruction> instructions)
   {

--- a/src/ValheimRAFT/ValheimRAFT.Unity/.idea/.idea.ValheimRAFT.Unity/.idea/workspace.xml
+++ b/src/ValheimRAFT/ValheimRAFT.Unity/.idea/.idea.ValheimRAFT.Unity/.idea/workspace.xml
@@ -6,6 +6,11 @@
   <component name="ChangeListManager">
     <list default="true" id="9eb05097-9d84-4b87-8e9a-0e73fcf3150e" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/../../../libs" beforeDir="false" afterPath="$PROJECT_DIR$/../../../libs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../ValheimRAFT.Patches/PlanBuild_Patch.cs" beforeDir="false" afterPath="$PROJECT_DIR$/../ValheimRAFT.Patches/PlanBuild_Patch.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/.idea.ValheimRAFT.Unity/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/.idea.ValheimRAFT.Unity/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Assets/ValheimVehicles/Shaders/VehicleSailShader.shader" beforeDir="false" afterPath="$PROJECT_DIR$/Assets/ValheimVehicles/Shaders/VehicleSailShader.shader" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../../ValheimVehicles/ValheimVehicles.Config/PhysicsConfig.cs" beforeDir="false" afterPath="$PROJECT_DIR$/../../ValheimVehicles/ValheimVehicles.Config/PhysicsConfig.cs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/../../ValheimVehicles/ValheimVehicles.Config/WaterConfig.cs" beforeDir="false" afterPath="$PROJECT_DIR$/../../ValheimVehicles/ValheimVehicles.Config/WaterConfig.cs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -38,12 +43,16 @@
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.burst@1.8.11/Tests/Editor/BurstStringSearchTests.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ide.rider@3.0.27/Rider/Editor/RiderScriptEditor.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.inputsystem@1.7.0/Samples~/Visualizers/VisualizationHelpers.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.render-pipelines.core@14.0.9/Editor/Volume/VolumeGizmoDrawer.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.render-pipelines.universal@14.0.9/Runtime/RenderingLayerUtils.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.searcher@4.9.2/Tests/Editor/SearcherTests.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ugui@1.0.0/Runtime/EventSystem/RaycastResult.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ugui@1.0.0/Runtime/UI/Core/IMaskable.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ugui@1.0.0/Runtime/UI/Core/Utility/VertexHelper.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ugui@1.0.0/Tests/Editor/Canvas/AssertionFailureOnOutputVertexCount.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ugui@1.0.0/Tests/Editor/RectMask2D/RectMask2DCulling.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ugui@1.0.0/Tests/Runtime/Button/ButtonTests.cs" root0="SKIP_HIGHLIGHTING" />
+    <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ugui@1.0.0/Tests/Runtime/EventSystem/PhysicsRaycasterTests.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.ugui@1.0.0/Tests/Runtime/TextEditor/TextEditorBackspaceDelete.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.visualscripting@1.9.4/Editor/VisualScripting.Core/Interface/Icons/Icons.cs" root0="SKIP_HIGHLIGHTING" />
     <setting file="file://$PROJECT_DIR$/Library/PackageCache/com.unity.visualscripting@1.9.4/Runtime/VisualScripting.Core/Serialization/SerializeAsAttribute.cs" root0="SKIP_HIGHLIGHTING" />
@@ -61,22 +70,22 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_ADD_EXTERNAL_FILES&quot;: &quot;true&quot;,
-    &quot;Attach to Unity Editor.Attach to Unity Editor.executor&quot;: &quot;Debug&quot;,
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;XThreadsFramesViewSplitterKey&quot;: &quot;0.3313253&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feat/watermesh-masking&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_ADD_EXTERNAL_FILES": "true",
+    "Attach to Unity Editor.Attach to Unity Editor.executor": "Debug",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "XThreadsFramesViewSplitterKey": "0.3313253",
+    "git-widget-placeholder": "feat/ladder-and-minor-tweaks",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RunManager" selected="Attach to Unity Editor.Attach to Unity Editor">
     <configuration name="Start Unity" type="RunUnityExe" factoryName="Unity Executable">
       <option name="EXE_PATH" value="C:\Program Files\Unity\Hub\Editor\2022.3.17f1\Editor\Unity.exe" />
@@ -171,6 +180,7 @@
       <workItem from="1730440747446" duration="129000" />
       <workItem from="1730955051216" duration="8034000" />
       <workItem from="1730964261074" duration="701000" />
+      <workItem from="1731143420981" duration="838000" />
     </task>
     <servers />
   </component>

--- a/src/ValheimRAFT/ValheimRAFT.Unity/Assets/ValheimVehicles/Shaders/VehicleSailShader.shader
+++ b/src/ValheimRAFT/ValheimRAFT.Unity/Assets/ValheimVehicles/Shaders/VehicleSailShader.shader
@@ -22,7 +22,7 @@
        _Metallic ("Metallic", Range(0, 1)) = 0
        _Cutoff ("Alpha Cutoff", Range(0, 1)) = 0.5
        _BumpScale ("Normal scale", Float) = 1
-       [MaterialToggle] _TwoSidedNormals ("Twosided normals", Float) = 0
+       [MaterialToggle] _TwoSidedNormals ("Twosided normals", Float) = 1
        _SphereNormals ("Spherical Normal", Range(0, 1)) = 0
        _SphereOffset ("Spherical offset", Float) = 0
        _EmissiveTex ("Emissive (RGB)", 2D) = "white" {}

--- a/src/ValheimRAFT/ValheimRAFT/RopeLadderComponent.cs
+++ b/src/ValheimRAFT/ValheimRAFT/RopeLadderComponent.cs
@@ -189,6 +189,12 @@ public class RopeLadderComponent : MonoBehaviour, Interactable, Hoverable
       return;
     }
 
+    if (Mathf.Abs(transform.rotation.eulerAngles.x) > 40 ||
+        Mathf.Abs(transform.rotation.eulerAngles.z) > 40)
+    {
+      return;
+    }
+
     if (rayMask == 0)
     {
       rayMask = LayerMask.GetMask("Default", "static_solid", "Default_small",
@@ -504,9 +510,9 @@ public class RopeLadderComponent : MonoBehaviour, Interactable, Hoverable
   public void OnNearTopExitForwards(Player player)
   {
     var deltaY = player.transform.position.y - m_exitPoint.position.y;
-    if (deltaY < 1f)
+    if (Mathf.Abs(deltaY) < 1f)
     {
-      player.transform.position += GetExitOffset();
+      player.transform.position = GetExitOffset();
     }
   }
 

--- a/src/ValheimRAFT/docs/ValheimRAFT_AutoDoc.md
+++ b/src/ValheimRAFT/docs/ValheimRAFT_AutoDoc.md
@@ -1,498 +1,636 @@
 
 ## Debug
 
-### Enable Sentry Metrics (requires sentryUnityPlugin)
+### Enable Sentry Metrics (requires sentryUnityPlugin) 
 - Description: Enable sentry debug logging. Requires sentry logging plugin installed to work. Sentry Logging plugin will make it easier to troubleshoot raft errors and detect performance bottlenecks. The bare minimum is collected, and only data related to ValheimRaft. See https://github.com/zolantris/ValheimMods/tree/main/src/ValheimRAFT#logging-metrics for more details about what is collected
 - Default Value: true
 
-### Debug logging for Vehicle/Raft
+### Debug logging for Vehicle/Raft 
 - Description: Outputs more debug logs for the Vehicle components. Useful for troubleshooting errors, but will spam logs
 - Default Value: false
 
 ## Deprecated Config
 
-### Initial Floor Height (V1 raft)
+### Initial Floor Height (V1 raft) 
 - Description: Allows users to set the raft floor spawn height. 0.45 was the original height in 1.4.9 but it looked a bit too low. Now people can customize it
 - Default Value: 0.6
 
 ## Config
 
-### pluginFolderName
+### pluginFolderName 
 - Description: Users can leave this empty. If they do not, the mod will attempt to match the folder string. Allows users to set the folder search name if their manager renames the folder, r2modman has a fallback case added to search for zolantris-ValheimRAFTDefault search values are an ordered list first one is always matching non-empty strings from this pluginFolderName.Folder Matches are:  zolantris-ValheimRAFT, zolantris-ValheimRAFT Zolantris-ValheimRAFT, and ValheimRAFT
-- Default Value:
+- Default Value: 
 
 ## Debug
 
-### RemoveStartMenuBackground
+### RemoveStartMenuBackground 
 - Description: Removes the start scene background, only use this if you want to speedup start time
 - Default Value: true
 
 ## Server config
 
-### Protect Vehicle pieces from breaking on Error
+### Protect Vehicle pieces from breaking on Error 
 - Description: Protects against crashes breaking raft/vehicle initialization causing raft/vehicles to slowly break pieces attached to it. This will make pieces attached to valid raft ZDOs unbreakable from damage, but still breakable with hammer
 - Default Value: true
 
-### AdminsCanOnlyBuildRaft
+### AdminsCanOnlyBuildRaft 
 - Description: ValheimRAFT hammer menu pieces are registered as disabled unless the user is an Admin, allowing only admins to create rafts. This will update automatically make sure to un-equip the hammer to see it apply (if your remove yourself as admin). Server / client does not need to restart
 - Default Value: false
 
-### AllowOldV1RaftRecipe
+### AllowOldV1RaftRecipe 
 - Description: Allows the V1 Raft to be built, this Raft is not performant, but remains in >=v2.0.0 as a Fallback in case there are problems with the new raft
 - Default Value: false
 
-### AllowExperimentalPrefabs
+### AllowExperimentalPrefabs 
 - Description: Allows >=v2.0.0 experimental prefabs such as Iron variants of slabs, hulls, and ribs. They do not look great so they are disabled by default
 - Default Value: false
 
 ## Rendering
 
-### Force Ship Owner Piece Update Per Frame
+### Force Ship Owner Piece Update Per Frame 
 - Description: Forces an update during the Update sync of unity meaning it fires every frame for the Ship owner who also owns Physics. This will possibly make updates better for non-boat owners. Noting that the boat owner is determined by the first person on the boat, otherwise the game owns it.
 - Default Value: false
 
 ## Server config
 
-### ServerRaftUpdateZoneInterval
+### ServerRaftUpdateZoneInterval 
 - Description: Allows Server Admin control over the update tick for the RAFT location. Larger Rafts will take much longer and lag out players, but making this ticket longer will make the raft turn into a box from a long distance away.
 - Default Value: 5
 
-### MakeAllPiecesWaterProof
+### MakeAllPiecesWaterProof 
 - Description: Makes it so all building pieces (walls, floors, etc) on the ship don't take rain damage.
 - Default Value: true
 
-### AllowFlight
+### AllowFlight 
 - Description: Allow the raft to fly (jump\crouch to go up and down)
 - Default Value: true
 
-### AllowCustomRudderSpeeds
+### AllowCustomRudderSpeeds 
 - Description: Allow the raft to use custom rudder speeds set by the player, these speeds are applied alongside sails at half and full speed. See advanced section for the actual speed settings.
 - Default Value: true
 
 ## Config
 
-### RaftCreativeHeight
+### RaftCreativeHeight 
 - Description: Sets the raftcreative command height, raftcreative is relative to the current height of the ship, negative numbers will sink your ship temporarily
 - Default Value: 5
 
 ## Floatation
 
-### Only Use Hulls For Floatation Collisions
+### Only Use Hulls For Floatation Collisions 
 - Description: Makes the Ship Hull prefabs be the sole source of collisions, meaning ships with wider tops will not collide at bottom terrain due to their width above water. Requires a Hull, without a hull it will previous box around all items in ship
 - Default Value: true
 
 ## Config
 
-### AnchorKeyboardShortcut
+### AnchorKeyboardShortcut 
 - Description: Anchor keyboard hotkey. Only applies to keyboard
 - Default Value: LeftShift
 
 ## Vehicles
 
-### HullFloatationColliderLocation
+### HullFloatationColliderLocation 
 - Description: Hull Floatation Collider will determine the location the ship floats and hovers above the sea. Average is the average height of all Vehicle Hull Pieces attached to the vehicle. The point calculate is the center of the prefab. Center is the center point of all the float boats. This center point is determined by the max and min height points included for ship hulls. Lowest is the lowest most hull piece will determine the float height, allowing users to easily raise the ship if needed by adding a piece at the lowest point of the ship. Custom allows for setting floatation between -20 and 20
-- Default Value: Center
+- Default Value: Bottom
 
-### HullFloatation Custom Offset
+### HullFloatation Custom Offset 
 - Description: Hull Floatation Collider Customization. Set this value and it will always make the ship float at that offset, will only work when HullFloatationColliderLocation=Custom. Positive numbers sink ship, negative will make ship float higher.
-- Default Value: 7.13615
+- Default Value: 0
 
-### EnableExactVehicleBounds
+### EnableExactVehicleBounds 
 - Description: Ensures that a piece placed within the raft is included in the float collider correctly. May not be accurate if the parent GameObjects are changing their scales above or below 1,1,1. Mods like Gizmo could be incompatible
-- Default Value: true
+- Default Value: false
 
 ## Debug
 
-### ShowShipState
-- Description:
+### ShowShipState 
+- Description: 
 - Default Value: true
 
 ## Propulsion
 
-### MaxPropulsionSpeed
+### MaxPropulsionSpeed 
 - Description: Sets the absolute max speed a ship can ever hit. This is capped on the vehicle, so no forces applied will be able to exceed this value. 20-30f is safe, higher numbers could let the ship fail off the map
-- Default Value: 200
+- Default Value: 45
 
-### MaxSailSpeed
+### MaxSailSpeed 
 - Description: Sets the absolute max speed a ship can ever hit with sails. Prevents or enables space launches, cannot exceed MaxPropulsionSpeed.
-- Default Value: 163.4272
+- Default Value: 30
 
-### MassPercentage
+### MassPercentage 
 - Description: Sets the mass percentage of the ship that will slow down the sails
-- Default Value: 10
+- Default Value: 55
 
-### SpeedCapMultiplier
+### SpeedCapMultiplier 
 - Description: Sets the speed at which it becomes significantly harder to gain speed per sail area
-- Default Value: 3
+- Default Value: 1
 
-### Rudder Back Speed
+### Rudder Back Speed 
 - Description: Set the Back speed of rudder, this will apply with sails
 - Default Value: 5
 
-### Rudder Slow Speed
+### Rudder Slow Speed 
 - Description: Set the Slow speed of rudder, this will apply with sails
+- Default Value: 4
+
+### Rudder Half Speed 
+- Description: Set the Half speed of rudder, this will apply with sails
 - Default Value: 5
 
-### Rudder Half Speed
-- Description: Set the Half speed of rudder, this will apply with sails
-- Default Value: 50
-
-### Rudder Full Speed
+### Rudder Full Speed 
 - Description: Set the Full speed of rudder, this will apply with sails
-- Default Value: 20
+- Default Value: 40
 
-### HasShipWeightCalculations
+### HasShipWeightCalculations 
 - Description: enables ship weight calculations for sail-force (sailing speed) and future propulsion, makes larger ships require more sails and smaller ships require less
 - Default Value: true
 
-### HasShipContainerWeightCalculations
+### HasShipContainerWeightCalculations 
 - Description: enables ship weight calculations for containers which affects sail-force (sailing speed) and future propulsion calculations. Makes ships with lots of containers require more sails
 - Default Value: false
 
 ## Debug
 
-### HasDebugSails
+### HasDebugSails 
 - Description: Outputs all custom sail information when saving and updating ZDOs for the sails. Debug only.
 - Default Value: false
 
 ## Propulsion
 
-### EnableCustomPropulsionConfig
+### EnableCustomPropulsionConfig 
 - Description: Enables all custom propulsion values
 - Default Value: false
 
-### SailCustomAreaTier1Multiplier
+### SailCustomAreaTier1Multiplier 
 - Description: Manual sets the sail wind area multiplier the custom tier1 sail. Currently there is only 1 tier
 - Default Value: 0.5
 
-### SailTier1Area
+### SailTier1Area 
 - Description: Manual sets the sail wind area of the tier 1 sail.
+- Default Value: 5
+
+### SailTier2Area 
+- Description: Manual sets the sail wind area of the tier 2 sail.
 - Default Value: 10
 
-### SailTier2Area
-- Description: Manual sets the sail wind area of the tier 2 sail.
+### SailTier3Area 
+- Description: Manual sets the sail wind area of the tier 3 sail.
 - Default Value: 20
 
-### SailTier3Area
-- Description: Manual sets the sail wind area of the tier 3 sail.
-- Default Value: 30
-
-### SailTier4Area
+### SailTier4Area 
 - Description: Manual sets the sail wind area of the tier 4 sail.
-- Default Value: 50
+- Default Value: 40
 
-### Flight Vertical Continues UntilToggled
-- Description: Saves the user's fingers by allowing the ship to continue to climb or descend without needing to hold the button
-- Default Value: false
+### FlightVerticalToggle 
+- Description: Flight Vertical Continues UntilToggled: Saves the user's fingers by allowing the ship to continue to climb or descend without needing to hold the button
+- Default Value: true
 
-### Only allow rudder speeds during flight
-- Description: Flight allows for different rudder speeds, only use those and ignore sails
+### FlightHasRudderOnly 
+- Description: Flight allows for different rudder speeds. Use rudder speed only. Do not use sail speed.
 - Default Value: false
 
 ## Graphics
 
-### Sails Fade In Fog
+### Sails Fade In Fog 
 - Description: Allow sails to fade in fog. Unchecking this will be slightly better FPS but less realistic. Should be fine to keep enabled
 - Default Value: true
 
 ## Sounds
 
-### Ship Sailing Sounds
+### Ship Sailing Sounds 
 - Description: Toggles the ship sail sounds.
 - Default Value: true
 
-### Ship Wake Sounds
+### Ship Wake Sounds 
 - Description: Toggles Ship Wake sounds. Can be pretty loud
 - Default Value: true
 
-### Ship In-Water Sounds
+### Ship In-Water Sounds 
 - Description: Toggles ShipInWater Sounds, the sound of the hull hitting water
 - Default Value: true
 
 ## Patches
 
-### DynamicLocations
+### DynamicLocations 
 - Description: Enables DynamicLocations mod to access ValheimRAFT/Vehicles identifiers.
 - Default Value: true
 
-### ComfyGizmo - Enable Patch
+### ComfyGizmo - Enable Patch 
 - Description: Patches relative rotation allowing for copying rotation and building while the raft is at movement, this toggle is only provided in case patches regress anything in Gizmos and players need a work around.
 - Default Value: false
 
-### ComfyGizmo - Vehicle Creative zero Y rotation
+### ComfyGizmo - Vehicle Creative zero Y rotation 
 - Description: Vehicle/Raft Creative mode will set all axises to 0 for rotation instead keeping the turn axis. Gizmo has issues with rotated vehicles, so zeroing things out is much safer. Works regardless of patch if mod exists
 - Default Value: true
 
-### Vehicles Prevent Pausing
+### Vehicles Prevent Pausing 
 - Description: Prevents pausing on a boat, pausing causes a TON of desync problems and can make your boat crash or other players crash
 - Default Value: true
 
-### Vehicles Prevent Pausing SinglePlayer
+### Vehicles Prevent Pausing SinglePlayer 
 - Description: Prevents pausing on a boat during singleplayer. Must have the Vehicle Prevent Pausing patch as well
-- Default Value: false
+- Default Value: true
 
-### Enable PlanBuild Patches (required to be on if you installed PlanBuild)
+### Enable PlanBuild Patches (required to be on if you installed PlanBuild) 
 - Description: Fixes the PlanBuild mod position problems with ValheimRaft so it uses localPosition of items based on the parent raft. This MUST be enabled to support PlanBuild but can be disabled when the mod owner adds direct support for this part of ValheimRAFT. PlanBuild mod can be found here. https://thunderstore.io/c/valheim/p/MathiasDecrock/PlanBuild/
 - Default Value: false
 
 ## Rams
 
-### ramDamageEnabled
+### ramDamageEnabled 
 - Description: Will keep the prefab available for aethetics only, will not do any damage nor will it initialize anything related to damage. Alternatives are using the damage tweaks.
 - Default Value: true
 
-### maximumDamage
+### maximumDamage 
 - Description: Maximum damage for all damages combined. This will throttle any calcs based on each damage value. The throttling is balanced and will fit the ratio of every damage value set. This allows for velocity to increase ram damage but still prevent total damage over specific values
 - Default Value: 200
 
-### maxDamageCap
+### maxDamageCap 
 - Description: enable damage caps
 - Default Value: true
 
-### slashDamage
+### slashDamage 
 - Description: slashDamage for Ram Blades. the base applied per hit on all items within the hit area. This damage is affected by velocity and ship mass.
 - Default Value: 0
 
-### bluntDamage
+### bluntDamage 
 - Description: bluntDamage the base applied per hit on all items within the hit area. This damage is affected by velocity and ship mass.
 - Default Value: 10
 
-### chopDamage
+### chopDamage 
 - Description: chopDamage for Ram Blades excludes Ram Stakes. the base applied per hit on all items within the hit area. This damage is affected by velocity and ship mass.. Will damage trees dependending on tool tier settings
-- Default Value: 50
+- Default Value: 5
 
-### pickaxeDamage
+### pickaxeDamage 
 - Description: pickDamage the base applied per hit on all items within the hit area. This damage is affected by velocity and ship mass. Will damage rocks as well as other entities
-- Default Value: 20
+- Default Value: 220
 
-### pierceDamage
+### pierceDamage 
 - Description: Pierce damage for Ram Stakes. the base applied per hit on all items within the hit area. This damage is affected by velocity and ship mass. Will damage rocks as well as other entities
-- Default Value: 20
+- Default Value: 55
 
-### percentageDamageToSelf
+### percentageDamageToSelf 
 - Description: Percentage Damage applied to the Ram piece per hit. Number between 0-1.
 - Default Value: 0.01
 
-### AllowContinuousDamage
+### AllowContinuousDamage 
 - Description: Rams will continue to apply damage based on their velocity even after the initial impact
 - Default Value: true
 
-### RamDamageToolTier
+### RamDamageToolTier 
 - Description: allows rams to damage both rocks, ores, and higher tier trees and/or prefabs. Tier 1 is bronze. Setting to 100 will allow damage to all types of materials
 - Default Value: 100
 
-### CanHitCharacters
+### CanHitCharacters 
 - Description: allows rams to hit characters/entities
 - Default Value: true
 
-### CanHitEnemies
+### CanHitEnemies 
 - Description: allows rams to hit enemies
 - Default Value: true
 
-### CanHitFriendly
+### CanHitFriendly 
 - Description: allows rams to hit friendlies
 - Default Value: true
 
-### CanDamageSelf
+### CanDamageSelf 
 - Description: allows rams to be damaged. The values set for the damage will be calculated
 - Default Value: true
 
-### CanHitEnvironmentOrTerrain
+### CanHitEnvironmentOrTerrain 
 - Description: allows rams to hit friendlies
 - Default Value: true
 
-### HitRadius
+### HitRadius 
 - Description: The base ram hit radius area. Stakes are always half the size, this will hit all pieces within this radius, capped between 0.1 and 10 for balance and framerate stability
-- Default Value: 5
+- Default Value: 40
 
-### RamHitInterval
+### RamHitInterval 
 - Description: Every X seconds, the ram will apply this damage
 - Default Value: 1
 
-### RamsCanBeRepaired
+### RamsCanBeRepaired 
 - Description: Allows rams to be repaired
 - Default Value: false
 
-### minimumVelocityToTriggerHit
+### minimumVelocityToTriggerHit 
 - Description: Minimum velocity required to activate the ram's damage
 - Default Value: 1
 
-### RamMaxVelocityMultiplier
+### RamMaxVelocityMultiplier 
 - Description: Damage of the ram is increased by an additional % based on the additional weight of the ship. 1500 mass at 1% would be 5 extra damage. IE 1500-1000 = 500 * 0.01 = 5.
 - Default Value: 1
 
-### DamageIncreasePercentagePerTier
+### DamageIncreasePercentagePerTier 
 - Description: Damage Multiplier per tier. So far only HardWood (Tier1) Iron (Tier3) available. With base value 1 a Tier 3 mult at 25% additive additional damage would be 1.5. IE (1 * 0.25 * 2 + 1) = 1.5
 - Default Value: 0.25
 
 ## PrefabConfig
 
-### startingPiece
+### RopeLadderEjectionPoint 
+- Description: The place the player is placed after they leave the ladder. Defaults to Y +0.25 and Z +0.5 meaning you are placed forwards of the ladder.
+- Default Value: {"x":0.0,"y":0.0,"z":0.0}
+
+### startingPiece 
 - Description: Allows you to customize what piece the raft initializes with. Admins only as this can be overpowered.
 - Default Value: Hull4X8
 
-### ropeLadderRunClimbSpeedMult
+### ropeLadderRunClimbSpeedMult 
 - Description: Allows you to customize how fast you can climb a ladder when in run mode
 - Default Value: 2
 
-### ropeLadderHints
+### ropeLadderHints 
 - Description: Shows the controls required to auto ascend/descend and run to speedup ladder
 - Default Value: true
 
 ## Vehicle Debugging
 
-### HasAutoAnchorDelay
-- Description: For realism, the ship continues even when nobody is onboard. This is meant for debugging logout points but also could be useful for realism
-- Default Value: true
+### DebugMetricsEnabled 
+- Description: Will locally log metrics for ValheimVehicles mods. Meant for debugging functional delays
+- Default Value: false
 
-### AutoAnchorDelayTimeInSeconds
+### DebugMetricsTimer 
+- Description: The interval in seconds that the logs output. Lower is performance heavy. Do not have this set to a low value. Requires EnableDebugMetrics to be enabled to update.
+- Default Value: 1
+
+### HasAutoAnchorDelay 
+- Description: For realism, the ship continues even when nobody is onboard. This is meant for debugging logout points but also could be useful for realism
+- Default Value: false
+
+### AutoAnchorDelayTimeInSeconds 
 - Description: For realism, the ship continues for X amount of time until it either unrenders or a player stops it.
 - Default Value: 10
 
-### Always Show Vehicle Colliders
+### Always Show Vehicle Colliders 
 - Description: Automatically shows the vehicle colliders useful for debugging the vehicle
 - Default Value: false
 
-### Vehicle Debug Menu
+### Vehicle Debug Menu 
 - Description: Enable the VehicleDebugMenu. This shows a GUI menu which has a few shortcuts to debugging/controlling vehicles.
 - Default Value: true
 
-### UNSTABLE_PositionAutoFix
+### UNSTABLE_PositionAutoFix 
 - Description: UNSTABLE due to vehicle center point shifting and not being in center of actual vehicle pieces - Automatically moves the vehicle if buried/stuck underground. The close to 0 the closer it will be to teleporting the vehicle above the ground. The higher the number the more lenient it is. Recommended to keep this number above 10. Lower can make the vehicle trigger an infinite loop of teleporting upwards and then falling and re-telporting while gaining velocity
 - Default Value: true
 
-### positionAutoFixThreshold
+### positionAutoFixThreshold 
 - Description: Threshold for autofixing stuck vehicles. Large values are less accurate but smaller values may trigger the autofix too frequently
-- Default Value: 10
+- Default Value: 5
 
 ## Debug
 
-### SyncShipPhysicsOnAllClients
+### SyncShipPhysicsOnAllClients 
 - Description: Makes all clients sync physics
-- Default Value: true
+- Default Value: false
 
 ## Propulsion
 
-### VehiclePhysicsMode
+### VehiclePhysicsMode 
 - Description: SyncRigidbody - Accurately syncs physics across clients, it causes jitters during high speed.
-  ForceSyncedRigidbody ignores all allowances that toggle SyncRigidbody related to flight. This will require a flight ascend value of 1 otherwise flight will be broken. Use this is there is problems with SyncRigidbody
-  DesyncedJointRigidbodyBody - is a new UNSTABLE (you have been warned) config that allows the player to smoothly move around the raft at high speeds even if they are not the host. Can cause the ship to glitch with anything that has to do with physics including ramps and other mods that add moving parts that could be added to the boat.
-- Default Value: SyncedRigidbody
+ForceSyncedRigidbody ignores all allowances that toggle SyncRigidbody related to flight. This will require a flight ascend value of 1 otherwise flight will be broken. Use this is there is problems with SyncRigidbody
+DesyncedJointRigidbodyBody - is a new UNSTABLE (you have been warned) config that allows the player to smoothly move around the raft at high speeds even if they are not the host. Can cause the ship to glitch with anything that has to do with physics including ramps and other mods that add moving parts that could be added to the boat.
+- Default Value: ForceSyncedRigidbody
 
-### turningPowerNoRudder
+### turningPowerNoRudder 
 - Description: Set the base turning power of the steering wheel
 - Default Value: 1
 
-### turningPowerWithRudder
+### turningPowerWithRudder 
 - Description: Set the turning power with a rudder
 - Default Value: 6
 
-### slowAndReverseWithoutControls
+### slowAndReverseWithoutControls 
 - Description: Vehicles do not require controls while in slow and reverse with a person on them
-- Default Value: true
+- Default Value: false
 
-### enableLandVehicles
+### enableLandVehicles 
 - Description: Vehicles can now float on land. What is realism. Experimental only until wheels are invented. Must use rudder speeds to move forwards.
 - Default Value: false
 
-### enableBaseGameSailRotation
+### enableBaseGameSailRotation 
 - Description: Lets the baseGame sails Tiers1-4 to rotate based on wind direction
 - Default Value: true
 
-### shouldLiftAnchorOnSpeedChange
+### shouldLiftAnchorOnSpeedChange 
 - Description: Lifts the anchor when using a speed change key, this is a QOL to prevent anchor from being required to be pressed when attempting to change the ship speed
-- Default Value: true
+- Default Value: false
 
-### FlightClimbingSpeed
-- Description: Ascent and Descent speed for the vehicle in the air. Numbers above 1 require turning the synced rigidbody for vehicle into another joint rigidbody.
-- Default Value: 5.690141
+### FlightClimbingOffset 
+- Description: Ascent and Descent speed for the vehicle in the air. This value is interpolated to prevent jitters.
+- Default Value: 5
+
+### UnderwaterClimbingOffset 
+- Description: Ascent and Descent speed for the vehicle in the water. This value is interpolated to prevent jitters.
+- Default Value: 5
 
 ## ModSupport:DynamicLocations
 
-### DynamicLocationLoginMovesPlayerToBed
+### DynamicLocationLoginMovesPlayerToBed 
 - Description: login/logoff point moves player to last interacted bed or first bed on ship
 - Default Value: true
 
 ## CustomMesh
 
-### Water Mask Prefabs Enabled
+### Water Mask Prefabs Enabled 
 - Description: Allows placing a dynamically sized cube that removes all water meshes intersecting with it. This also removes all water meshes when looking through it. So use it wisely, it's not perfect
 - Default Value: true
 
-### Enable Testing 4x4 Water Mask Prefabs, these are meant for demoing water obstruction.
+### Enable Testing 4x4 Water Mask Prefabs, these are meant for demoing water obstruction. 
 - Description: login/logoff point moves player to last interacted bed or first bed on ship
-- Default Value: true
+- Default Value: false
 
 ## Underwater: Debug
 
-### DEBUG_WaterDisplacementMeshPrimitive
+### DEBUG_ManualBallastOffsetEnabled 
+- Description: Enable manual ballast testing.
+- Default Value: false
+
+### DEBUG_ManualBallastOffset 
+- Description: Lets you test how ballast works by setting a value.
+- Default Value: 0
+
+### DEBUG_WaterDisplacementMeshPrimitive 
 - Description: Lets you choose from the water displacement mesh primitives. These will be stored as ZDOs. Not super user friendly yet...
 - Default Value: Cube
 
-### DEBUG_HasLiquidDepthOverride
-- Description: Enables liquid depth overrides
+### DEBUG_HasDepthOverrides 
+- Description: Enables depth overrides
 - Default Value: false
 
-### DEBUG_LiquidDepthOverride
-- Description: Force Overrides the liquid depth for character on boats. Likely will cause bobbing effect as it fights the onboard collider if it is below it.
+### DEBUG_WaterDepthOverride 
+- Description: Force Overrides the WATER depth for character on boats. Useful for testing how a player can swim to the lowest depth (liquid depth).
+- Default Value: 30
+
+### DEBUG_LiquidCacheDepthOverride 
+- Description: Force Overrides the liquid CACHED depth for character on boats.
+- Default Value: 0
+
+### DEBUG_LiquidDepthOverride 
+- Description: Force Overrides the LIQUID depth for character on boats.
 - Default Value: 15
+
+### DEBUG_SwimDepthOverride 
+- Description: Force Overrides the Swim depth for character on boats. Values above the swim depth force the player into a swim animation.
+- Default Value: 15
+
+### DEBUG_AutoBallastOffsetMultiplier 
+- Description: Adds more balast offset
+- Default Value: 1
 
 ## Underwater
 
-### FlipWatermeshMode
+### ManualBallast 
+- Description: Similar to flight mechanics but at sea. Defaults with Space/Jump to increase height and Sneak/Shift to decrease height uses the same flight comamnds.
+- Default Value: true
+
+### AutoBallast 
+- Description: Force moves the ship's float collider to the lowest section of the boat if that section is going to smash the ground
+- Default Value: true
+
+### BlockingColliderOffset 
+- Description: Sets the relative offset from the float collider. Can be negative or positive. Recommended is near the float collider. Slightly above it.
+- Default Value: 0.2
+
+### BallastSpeed 
+- Description: Adds more balast offset
+- Default Value: 1
+
+### AllowTamedEntiesUnderwater 
+- Description: Lets tamed animals underwater too. Could break or kill them depending on config.
+- Default Value: false
+
+### FlipWatermeshMode 
 - Description: Flips the water mesh underwater. This can cause some jitters. Turn it on at your own risk. It's improve immersion. Recommended to keep off for now while onboard to prevent underwater jitters due to camera colliding rapidly when water flips
-- Default Value: Disabled
+- Default Value: Everywhere
 
-### UnderwaterMaxDiveDepth
-- Description: Enforce a max depth for diving values higher will force the player to float to that value.
-- Default Value: 0
-
-### UnderwaterMaxCachedDiveDepth
-- Description: Enforce a max sinking depth for diving. Higher values can make the player swim to the depth instead of fall through the water. Recommended lower than 20
-- Default Value: 0
-
-### WaveSizeMultiplier
+### WaveSizeMultiplier 
 - Description: Make the big waves. This is a direct multiplier to height
-- Default Value: 0
+- Default Value: 1
 
-### UnderwaterShipCameraZoom
+### UnderwaterShipCameraZoom 
 - Description: Zoom value to allow for underwater zooming. Will allow camera to go underwater at values above 0. 0 will reset camera back to default.
 - Default Value: 5000
 
-### AllowedEntiesList
+### AllowedEntiesList 
 - Description: List separated by comma for entities that are allowed on the ship
-- Default Value:
+- Default Value: 
 
-### Use Underwater Fog
+### Use Underwater Fog 
 - Description: Adds fog to make underwater appear more realistic. This should be disabled if using Vikings do swim as this mod section is not compatible yet.
 - Default Value: true
 
-### Underwater fog color
+### Underwater fog color 
 - Description: Adds fog to make underwater appear more realistic. This should be disabled if using Vikings do swim as this mod section is not compatible yet.
-- Default Value: 009099FF
+- Default Value: 1A3B12FF
 
-### Underwater Fog Intensity
+### Underwater Fog Intensity 
 - Description: Adds fog to make underwater appear more realistic. This should be disabled if using Vikings do swim as this mod section is not compatible yet.
-- Default Value: 0.02
+- Default Value: 0.03
 
-### UnderwaterAccessMode
-- Description: Allows for walking underwater, anywhere, or onship, or eventually within the water displaced area only. Disabled with remove all water logic.
-- Default Value: WaterZoneOnly
+### UnderwaterAccessMode 
+- Description: Allows for walking underwater, anywhere, or onship, or eventually within the water displaced area only. Disabled with remove all water logic. DEBUG_WaterZoneOnly is not supported yet
+- Default Value: Everywhere
+
+## Vehicle Physics
+
+### flightAngularDamping 
+- Description: 
+- Default Value: 1
+
+### flightSidewaysDamping 
+- Description: 
+- Default Value: 1
+
+### flightDamping 
+- Description: 
+- Default Value: 1
+
+### flightSteerForce 
+- Description: 
+- Default Value: 1
+
+### flightSailForceFactor 
+- Description: 
+- Default Value: 0.1
+
+### flightDrag 
+- Description: 
+- Default Value: 1.2
+
+### flightAngularDrag 
+- Description: 
+- Default Value: 1.2
+
+### waterSteerForce 
+- Description: 
+- Default Value: 1
+
+### waterSidewaysDamping 
+- Description: 
+- Default Value: 0.3
+
+### waterAngularDamping 
+- Description: 
+- Default Value: 0.5
+
+### waterDamping 
+- Description: 
+- Default Value: 0.1
+
+### waterSailForceFactor 
+- Description: 
+- Default Value: 0.05
+
+### waterDrag 
+- Description: 
+- Default Value: 0.8
+
+### waterAngularDrag 
+- Description: 
+- Default Value: 0.8
+
+### submersibleAngularDamping 
+- Description: 
+- Default Value: 0.5
+
+### submersibleSidewaysDamping 
+- Description: 
+- Default Value: 0.5
+
+### submersibleDamping 
+- Description: 
+- Default Value: 0.5
+
+### submersibleSteerForce 
+- Description: 
+- Default Value: 0.5
+
+### submersibleSailForceFactor 
+- Description: 
+- Default Value: 0
+
+### submersibleDrag 
+- Description: 
+- Default Value: 1
+
+### submersibleAngularDrag 
+- Description: 
+- Default Value: 2
 
 ## Quick Start (DEBUG-ONLY)
 
-### QuickStartWorldName
+### QuickStartWorldName 
 - Description: Set the quick start World Name
-- Default Value: ZolVehicles
+- Default Value: ZolVehicles1
 
-### QuickStartWorldPassword
+### QuickStartWorldPassword 
 - Description: Set the quick start world password
 - Default Value: 123456
 
-### QuickStartEnabled
+### QuickStartEnabled 
 - Description: Enable Quick start
-- Default Value: false
+- Default Value: true
 
-### QuickStartWorldPlayerName
+### QuickStartWorldPlayerName 
 - Description: Quick start player name. Must be valid to start the quick start
 - Default Value: Zol

--- a/src/ValheimVehicles/ValheimVehicles.Attributes/GameCacheValueAttribute.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Attributes/GameCacheValueAttribute.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace ValheimVehicles.Attributes;
 
+/// <summary>
+/// Does nothing for now. But eventually this would be a way to mark methods as cacheable maybe via parent extension
+/// </summary>
 [AttributeUsage(AttributeTargets.Method)]
 public class GameCacheValueAttribute : Attribute
 {

--- a/src/ValheimVehicles/ValheimVehicles.Config/PhysicsConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Config/PhysicsConfig.cs
@@ -77,10 +77,11 @@ public class PhysicsConfig
   {
     Config = config;
 
-    flightAngularDamping = Config.Bind(SectionKey, "flightAngularDamping", 5f);
+    flightAngularDamping = Config.Bind(SectionKey, "flightAngularDamping", 1f);
     flightSidewaysDamping =
-      Config.Bind(SectionKey, "flightSidewaysDamping", 5f);
-    flightDamping = Config.Bind(SectionKey, "flightDamping", 5f);
+      Config.Bind(SectionKey, "flightSidewaysDamping", 1f);
+    flightDamping = Config.Bind(SectionKey, "flightDamping", 1f);
+
     flightSteerForce = Config.Bind(SectionKey, "flightSteerForce", 1f);
     flightSailForceFactor =
       Config.Bind(SectionKey, "flightSailForceFactor", 0.1f);
@@ -88,10 +89,13 @@ public class PhysicsConfig
     flightAngularDrag = Config.Bind(SectionKey, "flightAngularDrag", 1.2f);
 
     // water
-    waterAngularDamping = Config.Bind(SectionKey, "waterAngularDamping", 1f);
-    waterSidewaysDamping = Config.Bind(SectionKey, "waterSidewaysDamping", 1f);
     waterSteerForce = Config.Bind(SectionKey, "waterSteerForce", 1f);
-    waterDamping = Config.Bind(SectionKey, "waterDamping", 5f);
+
+    waterSidewaysDamping =
+      Config.Bind(SectionKey, "waterSidewaysDamping", 0.05f);
+    waterAngularDamping = Config.Bind(SectionKey, "waterAngularDamping", 0.01f);
+    waterDamping = Config.Bind(SectionKey, "waterDamping", 0.01f);
+
     waterSailForceFactor =
       Config.Bind(SectionKey, "waterSailForceFactor", 0.05f);
     waterDrag = Config.Bind(SectionKey, "waterDrag", 0.8f);
@@ -102,9 +106,10 @@ public class PhysicsConfig
       Config.Bind(SectionKey, "submersibleAngularDamping", 0.5f);
     submersibleSidewaysDamping =
       Config.Bind(SectionKey, "submersibleSidewaysDamping", 0.5f);
+    submersibleDamping = Config.Bind(SectionKey, "submersibleDamping", 0.5f);
+
     submersibleSteerForce =
       Config.Bind(SectionKey, "submersibleSteerForce", 0.5f);
-    submersibleDamping = Config.Bind(SectionKey, "submersibleDamping", 0.5f);
     submersibleSailForceFactor =
       Config.Bind(SectionKey, "submersibleSailForceFactor", 0f);
     submersibleDrag = Config.Bind(SectionKey, "submersibleDrag", 1.5f);

--- a/src/ValheimVehicles/ValheimVehicles.Config/PhysicsConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Config/PhysicsConfig.cs
@@ -93,8 +93,8 @@ public class PhysicsConfig
 
     waterSidewaysDamping =
       Config.Bind(SectionKey, "waterSidewaysDamping", 0.05f);
-    waterAngularDamping = Config.Bind(SectionKey, "waterAngularDamping", 0.01f);
-    waterDamping = Config.Bind(SectionKey, "waterDamping", 0.01f);
+    waterAngularDamping = Config.Bind(SectionKey, "waterAngularDamping", 0.05f);
+    waterDamping = Config.Bind(SectionKey, "waterDamping", 0.05f);
 
     waterSailForceFactor =
       Config.Bind(SectionKey, "waterSailForceFactor", 0.05f);

--- a/src/ValheimVehicles/ValheimVehicles.Config/PrefabConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Config/PrefabConfig.cs
@@ -36,7 +36,7 @@ public static class PrefabConfig
   {
     Config = config;
     RopeLadderEjectionOffset = config.Bind(SectionKey,
-      "RopeLadderEjectionPoint", new Vector3(0f, 0.25f, 0.5f),
+      "RopeLadderEjectionPoint", Vector3.zero,
       "The place the player is placed after they leave the ladder. Defaults to Y +0.25 and Z +0.5 meaning you are placed forwards of the ladder.");
 
     StartingPiece = config.Bind(SectionKey, "startingPiece",

--- a/src/ValheimVehicles/ValheimVehicles.Config/WaterConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Config/WaterConfig.cs
@@ -33,6 +33,9 @@ public static class WaterConfig
   public static ConfigEntry<PrimitiveType>
     DEBUG_WaterDisplacementMeshPrimitive { get; private set; } = null!;
 
+  public static ConfigEntry<float>
+    BlockingColliderOffset { get; private set; } = null!;
+
   public static ConfigEntry<WaterMeshFlipModeType>
     FlipWatermeshMode { get; private set; } = null!;
 
@@ -99,7 +102,7 @@ public static class WaterConfig
     null!;
 
   public static ConfigEntry<float> DEBUG_AutoBallastOffsetMultiplier = null!;
-  public static ConfigEntry<float> AutoBallastSpeed = null!;
+  public static ConfigEntry<float> BallastSpeed = null!;
   // public ConfigEntry<KeyboardShortcut> ManualBallastModifierKey { get; set; }
 
   /// <summary>
@@ -260,10 +263,18 @@ public static class WaterConfig
 
     AutoBallast.SettingChanged += (sender, args) => OnAutoBallastToggle();
 
-    AutoBallastSpeed = Config.Bind(
+    BlockingColliderOffset = Config.Bind(
       SectionKey,
-      "AutoBallastSpeed",
-      0.1f,
+      "BlockingColliderOffset",
+      0.2f,
+      ConfigHelpers.CreateConfigDescription(
+        "Sets the relative offset from the float collider. Can be negative or positive. Recommended is near the float collider. Slightly above it.",
+        true, true, new AcceptableValueRange<float>(-10f, 10f)));
+
+    BallastSpeed = Config.Bind(
+      SectionKey,
+      "BallastSpeed",
+      0.5f,
       ConfigHelpers.CreateConfigDescription(
         "Adds more balast offset",
         true, true, new AcceptableValueRange<float>(0.001f, 1)));

--- a/src/ValheimVehicles/ValheimVehicles.Config/WaterConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Config/WaterConfig.cs
@@ -70,7 +70,7 @@ public static class WaterConfig
   /// <summary>
   /// Waves
   /// </summary>
-  public static ConfigEntry<float> WaveSizeMultiplier =
+  public static ConfigEntry<float> DEBUG_WaveSizeMultiplier =
     null!;
 
   /// <summary>
@@ -237,6 +237,14 @@ public static class WaterConfig
       ConfigHelpers.CreateConfigDescription(
         "Adds more balast offset",
         true, true));
+
+    DEBUG_WaveSizeMultiplier = Config.Bind(
+      SectionKey,
+      "DEBUG_WaveSizeMultiplier",
+      1f,
+      ConfigHelpers.CreateConfigDescription(
+        "Make the big waves applies to DEBUG builds only. This is a direct multiplier to height might not work as expected. Debug value for fun",
+        false, false, new AcceptableValueRange<float>(0, 5f)));
   }
 
   public static void BindConfig(ConfigFile config)
@@ -293,16 +301,8 @@ public static class WaterConfig
       "FlipWatermeshMode",
       WaterMeshFlipModeType.Disabled,
       ConfigHelpers.CreateConfigDescription(
-        "Flips the water mesh underwater. This can cause some jitters. Turn it on at your own risk. It's improve immersion. Recommended to keep off for now while onboard to prevent underwater jitters due to camera colliding rapidly when water flips",
+        "Flips the water mesh underwater. This can cause some jitters. Turn it on at your own risk. It's improve immersion. Recommended to keep off if you dislike seeing a bit of tearing in the water meshes. Flipping camera above to below surface should fix things.",
         true, true));
-
-    WaveSizeMultiplier = Config.Bind(
-      SectionKey,
-      "WaveSizeMultiplier",
-      1f,
-      ConfigHelpers.CreateConfigDescription(
-        "Make the big waves. This is a direct multiplier to height",
-        false, false, new AcceptableValueRange<float>(0, 5f)));
 
     UnderwaterShipCameraZoom = Config.Bind(
       SectionKey,

--- a/src/ValheimVehicles/ValheimVehicles.Config/WaterConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Config/WaterConfig.cs
@@ -248,7 +248,7 @@ public static class WaterConfig
     ManualBallast = Config.Bind(
       SectionKey,
       "ManualBallast",
-      true,
+      false,
       ConfigHelpers.CreateConfigDescription(
         "Similar to flight mechanics but at sea. Defaults with Space/Jump to increase height and Sneak/Shift to decrease height uses the same flight comamnds.",
         true, true));
@@ -338,7 +338,7 @@ public static class WaterConfig
     UnderWaterFogColor = Config.Bind(
       SectionKey,
       "Underwater fog color",
-      new Color(0f, 0.57f, 0.6f),
+      new Color(0.10f, 0.23f, 0.07f, 1.00f),
       ConfigHelpers.CreateConfigDescription(
         "Adds fog to make underwater appear more realistic. This should be disabled if using Vikings do swim as this mod section is not compatible yet.",
         true));
@@ -346,7 +346,7 @@ public static class WaterConfig
     UnderWaterFogIntensity = Config.Bind(
       SectionKey,
       "Underwater Fog Intensity",
-      0.2f,
+      0.03f,
       ConfigHelpers.CreateConfigDescription(
         "Adds fog to make underwater appear more realistic. This should be disabled if using Vikings do swim as this mod section is not compatible yet.",
         true));

--- a/src/ValheimVehicles/ValheimVehicles.Helpers/WaterZoneUtils.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Helpers/WaterZoneUtils.cs
@@ -86,7 +86,7 @@ public static class WaterZoneUtils
   /// <param name="character"></param>
   /// <param name="waterZoneData"></param>
   /// <returns></returns>
-  [GameCacheValue(name: "IsOnboard", intervalInSeconds: 1f)]
+  // [GameCacheValue(name: "IsOnboard", intervalInSeconds: 1f)]
   public static bool IsOnboard(Character character,
     out WaterZoneCharacterData? waterZoneData)
   {

--- a/src/ValheimVehicles/ValheimVehicles.Patches/WaterVolume_MeshFlipPatches.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Patches/WaterVolume_MeshFlipPatches.cs
@@ -66,11 +66,15 @@ internal class WaterVolume_WaterPatches
         WaterConfig.UnderwaterAccessModeType.Disabled) return;
     if (GameCamera.instance)
     {
-      WaterLevelCamera =
+      var currentSurfaceLevel =
         __instance.GetWaterSurface(GameCamera.instance.transform.position);
+      WaterLevelCamera = currentSurfaceLevel > ZoneSystem.instance.m_waterLevel
+        ? ZoneSystem.instance.m_waterLevel
+        : currentSurfaceLevel;
     }
   }
 
+#if DEBUG
   [HarmonyPatch(typeof(WaterVolume), nameof(WaterVolume.CreateWave))]
   [HarmonyPostfix]
   private static void CreateWave(WaterVolume __instance, float __result)
@@ -78,8 +82,9 @@ internal class WaterVolume_WaterPatches
     if (WaterConfig.UnderwaterAccessMode.Value ==
         WaterConfig.UnderwaterAccessModeType.Disabled) return;
 
-    __result *= WaterConfig.WaveSizeMultiplier.Value;
+    __result *= WaterConfig.DEBUG_WaveSizeMultiplier.Value;
   }
+#endif
 
   private static float lastFlippedAllInvoke = 0f;
 
@@ -182,7 +187,7 @@ internal class WaterVolume_WaterPatches
         WaterConfig.WaterMeshFlipModeType.Disabled) return;
 
     UpdateCameraState();
-    // UpdateMesh(__instance, normalizedDepth);
+    UpdateMesh(__instance, normalizedDepth);
   }
 
   private static void UpdateMesh(WaterVolume __instance,

--- a/src/ValheimVehicles/ValheimVehicles.Prefabs/Registry/SwitchAndLeverPrefabs.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Prefabs/Registry/SwitchAndLeverPrefabs.cs
@@ -54,6 +54,10 @@ public class SwitchAndLeverPrefabs : IRegisterPrefab
 
   public void Register(PrefabManager prefabManager, PieceManager pieceManager)
   {
+    // Not registering prefabs in production as this does nothing for now.
+
+#if DEBUG
     RegisterToggleSwitch(prefabManager, pieceManager);
+#endif
   }
 }

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
@@ -720,9 +720,10 @@ public class VehiclePiecesController : MonoBehaviour, IMonoUpdater
     }
 
     if (m_body.collisionDetectionMode !=
-        CollisionDetectionMode.ContinuousDynamic)
+        CollisionDetectionMode.Discrete)
     {
-      m_body.collisionDetectionMode = CollisionDetectionMode.ContinuousDynamic;
+      m_body.collisionDetectionMode =
+        CollisionDetectionMode.Discrete;
     }
 
     if (m_fixedJoint.connectedBody)
@@ -730,9 +731,10 @@ public class VehiclePiecesController : MonoBehaviour, IMonoUpdater
       m_fixedJoint.connectedBody = null;
     }
 
-    m_body.MovePosition(VehicleInstance.MovementController.m_body.position);
-    m_body.MoveRotation(
-      VehicleInstance.MovementController.m_body.rotation);
+    m_body.Move(
+      VehicleInstance.MovementController.m_body.position,
+      VehicleInstance.MovementController.m_body.rotation
+    );
   }
 
   public void JointSync()
@@ -749,7 +751,7 @@ public class VehiclePiecesController : MonoBehaviour, IMonoUpdater
   }
 
   private bool IsNotFlying =>
-    Mathf.Approximately(VehicleInstance?.Instance?.TargetHeight ?? 0f, 0f) ||
+    !VehicleInstance?.MovementController?.IsFlying() ?? false ||
     ValheimRaftPlugin.Instance.AllowFlight.Value == false;
 
   private bool IsPhysicsForceSynced =
@@ -2643,7 +2645,8 @@ public class VehiclePiecesController : MonoBehaviour, IMonoUpdater
      * - may need an additional size
      * - may need more logic for water masks (hiding water on boat) and other boat magic that has not been added yet.
      */
-    var blockingColliderCenterY = floatColliderCenterOffset.y + 0.2f;
+    var blockingColliderCenterY = floatColliderCenterOffset.y +
+                                  WaterConfig.BlockingColliderOffset.Value;
     var blockingColliderCenterOffset = new Vector3(_vehicleBounds.center.x,
       blockingColliderCenterY, _vehicleBounds.center.z);
     var blockingColliderSize = new Vector3(

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
@@ -730,33 +730,9 @@ public class VehiclePiecesController : MonoBehaviour, IMonoUpdater
       m_fixedJoint.connectedBody = null;
     }
 
-    var lastOffset = VehicleInstance.MovementController.m_body.position -
-                     m_body.position;
-    var lastPlayersPosition =
-      MovementController?.m_players.Select(x => x.transform.localPosition)
-        .ToList();
-
     m_body.MovePosition(VehicleInstance.MovementController.m_body.position);
     m_body.MoveRotation(
       VehicleInstance.MovementController.m_body.rotation);
-
-    // In theory should make the players sync properly while moving at speed. No more jittery
-    if (MovementController?.m_players != null && lastPlayersPosition != null)
-    {
-      for (var i = 0; i < MovementController.m_players.Count; i++)
-      {
-        var expectedOffset = lastPlayersPosition[i] + lastOffset;
-        if (Mathf.Approximately(expectedOffset.magnitude,
-              MovementController.m_players[i].transform.localPosition
-                .magnitude))
-        {
-          continue;
-        }
-
-        MovementController.m_players[i].transform.localPosition =
-          expectedOffset;
-      }
-    }
   }
 
   public void JointSync()

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehicleShip.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehicleShip.cs
@@ -460,6 +460,23 @@ public class VehicleShip : MonoBehaviour, IVehicleShip
     VehicleDebugHelpersInstance =
       gameObject.AddComponent<VehicleDebugHelpers>();
 
+    // if (_movementController != null &&
+    //     _movementController.DebugTargetHeightObj == null)
+    // {
+    //   MovementController.DEBUG_VisualizeFloatPoint();
+    // }
+
+    // if (MovementController.DebugTargetHeightObj)
+    // {
+    //   VehicleDebugHelpersInstance.AddColliderToRerender(
+    //     new DrawTargetColliders()
+    //     {
+    //       collider = MovementController.DebugTargetHeightObj
+    //         .GetComponent<BoxCollider>(),
+    //       lineColor = Color.orange,
+    //       parent = gameObject
+    //     });
+    // }
 
     VehicleDebugHelpersInstance.AddColliderToRerender(new DrawTargetColliders()
     {

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/WaterZoneController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/WaterZoneController.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.Serialization;
 using ValheimVehicles.Attributes;
 using ValheimVehicles.Config;
+using ValheimVehicles.Helpers;
 using ValheimVehicles.Prefabs;
 using ValheimVehicles.LayerUtils;
 using ValheimVehicles.Vehicles;
@@ -118,7 +119,7 @@ public class WaterZoneController : CreativeModeColliderComponent
       WaterConfig.UnderwaterAccessModeType.Disabled => false,
       WaterConfig.UnderwaterAccessModeType.Everywhere => true,
       WaterConfig.UnderwaterAccessModeType.OnboardOnly =>
-        VehicleOnboardController.IsCharacterOnboard(character),
+        WaterZoneUtils.IsOnboard(character),
       WaterConfig.UnderwaterAccessModeType.DEBUG_WaterZoneOnly =>
         IsInWaterFreeZone(
           character),

--- a/valheim.targets
+++ b/valheim.targets
@@ -381,7 +381,7 @@
         <Exec Condition="$(AssemblyName) == 'SentryUnityWrapper'" Command="xcopy &quot;$(SolutionDir)\SentryUnity\1.8.0\runtime&quot; &quot;$(PluginDeployPath)\&quot; /q /s /y /i"/>
         <!--        <Exec Command="xcopy &quot;$(TargetDir)&quot; &quot;$(PluginDeployPath)\&quot; /q /s /y /i"/>-->
 
-        <!--        <Exec Condition="Exists('$(AssetsDir)')" Command="xcopy /d &quot;$(AssetsDir)&quot; &quot;$(PluginDeployPath)\Assets\&quot; /E/H/Y"/>-->
+        <Exec Condition="Exists('$(AssetsDir)')" Command="xcopy /d &quot;$(AssetsDir)&quot; &quot;$(PluginDeployPath)\Assets\&quot; /E/H/Y"/>
         <Exec Condition="Exists('$(AssetsDir)Translations\English\')" Command="xcopy /d &quot;$(AssetsDir)Translations\English\&quot; &quot;$(PluginDeployPath)\Assets\Translations\English\&quot; /E/H/Y"/>
     </Target>
     <!--     Condition=" $(AssemblyName) == 'ValheimRAFT' And Exists('$(SandboxiePluginDeployPath)') And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "-->


### PR DESCRIPTION
## Features 

- Resolve some twitchy ballast collider issues
- Make rudder force apply at worldcenter of mass...less likely to flip at high speed.
- **QOL:** Make ladders have a exit point that works. Add an additional player configurable offset that adds on top of this value. Only functions at the TOP of the ladder.

## TODOS (outside of this PR)
- [ ] Move to a ballast collider (Likely the FlotationCollider does this) that is static non-solid or a layer that  is not solid that cannot be interacted with the water. We need a point and collider that handles the ship current ballast target (TargetHeight)
- [ ] The blocking collider needs to be adjusted to include the whole ship or consist of two colliders that protect the top of the ship and bottom to avoid going through the ground .
- [ ] The blocking collider needs a front scoop that prevents clipping the center into the ground then getting in a very bad flipping rotation whirl state. Happens at high speeds or high ballast or in a rotation state that is >(Abs(40) degrees)