### PR TITLE
Feat/improve boat ownership transfer

### DIFF
--- a/src/ValheimVehicles/ValheimVehicles.ConsoleCommands/VehicleCommands.cs
+++ b/src/ValheimVehicles/ValheimVehicles.ConsoleCommands/VehicleCommands.cs
@@ -42,6 +42,7 @@ public class VehicleCommands : ConsoleCommand
     public const string toggleOceanSway = "toggleOceanSway";
     public const string upgradeToV2 = "upgradeShipToV2";
     public const string downgradeToV1 = "downgradeShipToV1";
+    public const string resetVehicleOwner = "resetLocalOwnership";
   }
 
   public override string Help => OnHelp();
@@ -120,10 +121,33 @@ public class VehicleCommands : ConsoleCommand
       case VehicleCommandArgs.moveUp:
         VehicleMoveVertically(nextArgs);
         break;
+      case VehicleCommandArgs.resetVehicleOwner:
+        VehicleOwnerReset();
+        break;
       case VehicleCommandArgs.help:
         Logger.LogMessage(OnHelp());
         break;
     }
+  }
+
+  public void VehicleOwnerReset()
+  {
+    var currentVehicle =
+      GetNearestVehicleShip(Player.m_localPlayer.transform.position);
+    if (currentVehicle?.MovementController == null)
+    {
+      Logger.LogMessage("No vehicle nearby");
+      return;
+    }
+
+    if (!VehicleOnboardController.IsCharacterOnboard(Player.m_localPlayer))
+    {
+      Logger.LogMessage(
+        "You player is not onboard any vehicle. You must be onboard the vehicle to safely take control of it.");
+      return;
+    }
+
+    currentVehicle.MovementController.ForceSetOwner();
   }
 
   public static void FloatArgErrorMessage(string arg)
@@ -752,6 +776,7 @@ public class VehicleCommands : ConsoleCommand
     VehicleCommandArgs.colliderEditMode,
     VehicleCommandArgs.move,
     VehicleCommandArgs.moveUp,
+    VehicleCommandArgs.resetVehicleOwner,
   ];
 
   public override string Name => "vehicle";

--- a/src/ValheimVehicles/ValheimVehicles.Propulsion/Rudder/SteeringWheelComponent.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Propulsion/Rudder/SteeringWheelComponent.cs
@@ -319,7 +319,7 @@ public class SteeringWheelComponent : MonoBehaviour, Hoverable, Interactable,
 
     if (!ShipInstance?.Instance?.MovementController) return false;
 
-    ShipInstance.Instance.MovementController.SendRequestControl(
+    ShipInstance.Instance.MovementController?.SendRequestControl(
       player.GetPlayerID(), AttachPoint);
     return true;
   }

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehicleMovementController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehicleMovementController.cs
@@ -2243,8 +2243,18 @@ public class VehicleMovementController : ValheimBaseGameShip, IVehicleMovement,
     CancelInvoke(nameof(SyncTargetHeight));
   }
 
+  /// <summary>
+  /// Force sets the owner after RPC fails to be sent.
+  /// </summary>
+  public void ForceSetOwner()
+  {
+    if (vehicleShip.NetView == null) return;
+    vehicleShip.NetView.m_zdo.SetOwner(Player.m_localPlayer.GetPlayerID());
+  }
+
   public void SendRequestControl(long playerId, Transform attachTransform)
   {
+    Invoke(nameof(ForceSetOwner), 2f);
     m_nview?.InvokeRPC(nameof(RPC_RequestControl),
       [playerId, attachTransform]);
   }
@@ -2929,6 +2939,8 @@ public class VehicleMovementController : ValheimBaseGameShip, IVehicleMovement,
 
   private void RPC_RequestResponse(long sender, bool granted)
   {
+    // Cancels the invocation of this fallback method if the owner of the boat does not respond quick enough.
+    CancelInvoke(nameof(ForceSetOwner));
     if (!Player.m_localPlayer || !ShipInstance?.Instance)
     {
       return;

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
@@ -827,7 +827,7 @@ public class VehiclePiecesController : MonoBehaviour, IMonoUpdater
   public void CustomUpdate(float deltaTime, float time)
   {
     Client_UpdateAllPieces();
-    Sync();
+    // Sync();
   }
 
   private void UpdateBedPiece(Bed mBedPiece)
@@ -851,7 +851,7 @@ public class VehiclePiecesController : MonoBehaviour, IMonoUpdater
 
   public void CustomLateUpdate(float deltaTime)
   {
-    Sync();
+    // Sync();
     if (!ZNet.instance.IsServer())
     {
       Client_UpdateAllPieces();

--- a/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Vehicles/Controllers/VehiclePiecesController.cs
@@ -732,6 +732,8 @@ public class VehiclePiecesController : MonoBehaviour, IMonoUpdater
       m_fixedJoint.connectedBody = null;
     }
 
+    Physics.SyncTransforms();
+
     m_body.Move(
       VehicleInstance.MovementController.m_body.position,
       VehicleInstance.MovementController.m_body.rotation
@@ -851,7 +853,7 @@ public class VehiclePiecesController : MonoBehaviour, IMonoUpdater
 
   public void CustomLateUpdate(float deltaTime)
   {
-    // Sync();
+    Sync();
     if (!ZNet.instance.IsServer())
     {
       Client_UpdateAllPieces();

--- a/valheim.targets
+++ b/valheim.targets
@@ -387,15 +387,15 @@
     <!--     Condition=" $(AssemblyName) == 'ValheimRAFT' And Exists('$(SandboxiePluginDeployPath)') And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "-->
     <Target Name="Copy_To_R2ModMan_vm" AfterTargets="Copy_To_R2ModMan" Condition="'$(IsRunnable)' == 'true' and '$(SandBoxieFileExitCode)' == '0'">
         <!--   Will only run if the above passes     -->
-        <Exec Condition="'$(FilesCheckExitCode)' == '0' And Exists('$(OutDir)$(AssemblyName).dll')" Command="copy &quot;$(OutDir)$(AssemblyName).dll&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).dll&quot;"/>
-        <Exec Condition="'$(FilesCheckExitCode)' == '0' And Exists('$(OutDir)$(AssemblyName).pdb')" Command="copy &quot;$(OutDir)$(AssemblyName).pdb&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).pdb&quot;"/>
-        <Exec Condition="'$(FilesCheckExitCode)' == '0' And Exists('$(OutDir)$(AssemblyName).mdb')" Command="copy &quot;$(OutDir)$(AssemblyName).mdb&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).mdb&quot;"/>
+        <Exec Condition="Exists('$(OutDir)$(AssemblyName).dll')" Command="copy &quot;$(OutDir)$(AssemblyName).dll&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).dll&quot;"/>
+        <Exec Condition="Exists('$(OutDir)$(AssemblyName).pdb')" Command="copy &quot;$(OutDir)$(AssemblyName).pdb&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).pdb&quot;"/>
+        <Exec Condition="Exists('$(OutDir)$(AssemblyName).mdb')" Command="copy &quot;$(OutDir)$(AssemblyName).mdb&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).mdb&quot;"/>
 
-        <Exec Condition="'$(FilesCheckExitCode)' == '0' And $(AssemblyName) == 'SentryUnityWrapper'" Command="xcopy &quot;$(SolutionDir)\SentryUnity\1.8.0\runtime&quot; &quot;$(SandboxiePluginDeployPath)\&quot; /q /s /y /i"/>
+        <Exec Condition="$(AssemblyName) == 'SentryUnityWrapper'" Command="xcopy &quot;$(SolutionDir)\SentryUnity\1.8.0\runtime&quot; &quot;$(SandboxiePluginDeployPath)\&quot; /q /s /y /i"/>
         <!--        <Exec Condition="'$(FilesCheckExitCode)' == '0'" Command="xcopy &quot;$(TargetDir)&quot; &quot;$(SandboxiePluginDeployPath)\&quot; /q /s /y /i"/>-->
 
-        <Exec Condition="'$(FilesCheckExitCode)' == '0' And Exists('$(AssetsDir)')" Command="xcopy /d &quot;$(AssetsDir)&quot; &quot;$(SandboxiePluginDeployPath)\Assets\&quot; /E/H/Y"/>
-        <Exec Condition="'$(FilesCheckExitCode)' == '0' And Exists('$(AssetsDir)Translations\English\')" Command="xcopy /d &quot;$(AssetsDir)Translations\English\&quot; &quot;$(SandboxiePluginDeployPath)\Assets\Translations\English\&quot; /E/H/Y"/>
+        <Exec Condition="Exists('$(AssetsDir)')" Command="xcopy /d &quot;$(AssetsDir)&quot; &quot;$(SandboxiePluginDeployPath)\Assets\&quot; /E/H/Y"/>
+        <Exec Condition="Exists('$(AssetsDir)Translations\English\')" Command="xcopy /d &quot;$(AssetsDir)Translations\English\&quot; &quot;$(SandboxiePluginDeployPath)\Assets\Translations\English\&quot; /E/H/Y"/>
     </Target>
     <Target Name="Generate_Mod_Archive" AfterTargets="PostBuildEvent" Condition=" '$(Configuration)|$(Platform)' == 'Release Archive|AnyCPU' ">
         <PropertyGroup>


### PR DESCRIPTION
- fixes regression of 2.4.x which did not allow turning wheel for non-owners.
- adds a delay that unsets the owner if the owner does not respond within 2 seconds.