### PR TITLE
Feat/wearntear eventing logic to update meshes

### DIFF
--- a/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/BasePiecesController.cs
+++ b/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/BasePiecesController.cs
@@ -385,18 +385,15 @@ namespace ValheimVehicles.SharedScripts
       // todo get this background thread working
       // GenerateConvexHullOnBackgroundThread(clusterThreshold, callback);
     }
-    /// <summary>
-    /// </summary>
-    /// TODO this method should be removed once BackgroundThread is optimized.
-    /// 
-    /// <param name="maxClusters"></param>
-    /// <param name="callback"></param>
-    public void GenerateConvexHullOnMainThread(float maxClusters, Action? callback)
-    {
-      verts.Clear();
-      tris.Clear();
-      normals.Clear();
 
+    /// <summary>
+    /// Point getter
+    /// </summary>
+    ///
+    /// Todo add a nativeArray or swap to nativeslice of nativearrays from points to avoid allocations.
+    /// <returns></returns>
+    public List<Vector3> GetPoints()
+    {
       var points = new List<Vector3>();
       if (isBasicHullCalculation)
       {
@@ -434,6 +431,24 @@ namespace ValheimVehicles.SharedScripts
           }
         }
       }
+
+      return points;
+      // var nativePoints = new NativeArray<Vector3>(points.Count, Allocator.Persistent);
+      // return nativePoints;
+    }
+    /// <summary>
+    /// </summary>
+    /// TODO this method should be removed once BackgroundThread is optimized.
+    /// 
+    /// <param name="maxClusters"></param>
+    /// <param name="callback"></param>
+    public void GenerateConvexHullOnMainThread(float maxClusters, Action? callback)
+    {
+      verts.Clear();
+      tris.Clear();
+      normals.Clear();
+
+      var points = GetPoints();
       
       // We cannot generate a convex collider with so view points. This is not a good situation to be in.
       // todo add a fallback that uses a simple box collider in this case. (IE THE BASIC RENDER)

--- a/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/ConvexHullCalculator.cs
+++ b/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/ConvexHullCalculator.cs
@@ -107,7 +107,7 @@ namespace ValheimVehicles.SharedScripts
       SanitizePointsFast(points, SANITIZE_TOLERANCE, sanitizedPoints);
 
       var currentLoopDepth = 0;
-      var maxLoopDepth = sanitizedPoints.Count * maxLoopDepthMultiplier;
+      var maxLoopDepth = Math.Min(sanitizedPoints.Count * maxLoopDepthMultiplier, 200);
       Initialize(sanitizedPoints, splitVerts);
 
       GenerateInitialHull(sanitizedPoints);

--- a/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/IWearNTearStub.cs
+++ b/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/IWearNTearStub.cs
@@ -12,6 +12,9 @@ namespace ValheimVehicles.SharedScripts
   public interface IWearNTearStub
   {
     Action m_onDestroyed { get; set; }
+
+    // an internal method we use to see if a mesh must be updated after repair.
+    Action m_onHealthVisualChange { get; set; }
     public GameObject? m_new { get; }
     public GameObject? m_worn { get; }
     public GameObject? m_broken { get; }

--- a/src/ValheimRAFT/ValheimRAFT.Patches/WearNTear_Patch.cs
+++ b/src/ValheimRAFT/ValheimRAFT.Patches/WearNTear_Patch.cs
@@ -8,6 +8,8 @@ using ValheimRAFT.Util;
 using ValheimVehicles.Config;
 using ValheimVehicles.Prefabs;
 using ValheimVehicles.Prefabs.Registry;
+using ValheimVehicles.SharedScripts;
+using ValheimVehicles.ValheimVehicles.Providers;
 using ValheimVehicles.Vehicles;
 using ValheimVehicles.Vehicles.Components;
 using ZdoWatcher;
@@ -44,6 +46,25 @@ public class WearNTear_Patch
 
     __result = false;
     return false;
+  }
+
+  [HarmonyPatch(typeof(WearNTear), "Repair")]
+  [HarmonyPostfix]
+  private static void WearNTear_Repair_AllowMeshUpdate(WearNTear __instance)
+  {
+    MeshClusterController.CanUpdateHealthItem = true;
+  }
+
+
+  /// <summary>
+  /// for detecting WearNTear changes when using ClusterMeshes
+  /// </summary>
+  /// <param name="__instance"></param>
+  [HarmonyPatch(typeof(WearNTear), "SetHealthVisual")]
+  [HarmonyPostfix]
+  private static void WearNTear_SetHealthVisual_UpdateCombinedMeshes(WearNTear __instance)
+  {
+    WearNTearIntegrationProvider.WearNTearAdapter.OnHealthVisualChange(__instance);
   }
 
   /*


### PR DESCRIPTION
# Overview

This is not ready. I'm pausing work on this. But the WearNTear features once complete would allow a more robust way to apply these cluster mesh calcs across vehicles and eventually generic structures. Idea is to make these calcs decoupled so it can be made into it's own standalone mod.

This would essentially free up building across all game worlds and make rendering significantly more efficient for large buildings. (when in frame).

## Current Features
- Adds onRepair eventing logic to only update meshes onRepair and onDestroy
  - TODO: onRepair does not work as intended since it would require the wearNTear to track previous and current states on health change.

## WIP Ideas
- Add onDamage eventing logic to update combined meshes...likely bad performance here. Best to prevent this update from even happening.
  - Add a onDamage check to only include objects that have not been damaged within X time.
  - If an object is damaged. Exclude it from the combined clustering immediately.
  