### PR TITLE
Feat/swivel multiplayer fixes

### DIFF
--- a/ValheimMods.sln
+++ b/ValheimMods.sln
@@ -52,6 +52,8 @@ Global
 		{6015B165-2627-40A7-8CA1-3E6B6CD7CB49}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6015B165-2627-40A7-8CA1-3E6B6CD7CB49}.Debug Run ClientServer|Any CPU.ActiveCfg = Debug Run ClientServer|Any CPU
 		{6015B165-2627-40A7-8CA1-3E6B6CD7CB49}.Debug Run ClientServer|Any CPU.Build.0 = Debug Run ClientServer|Any CPU
+		{6015B165-2627-40A7-8CA1-3E6B6CD7CB49}.Release Run Server|Any CPU.ActiveCfg = Release Run Server|Any CPU
+		{6015B165-2627-40A7-8CA1-3E6B6CD7CB49}.Release Run Server|Any CPU.Build.0 = Release Run Server|Any CPU
 		{E9B48BE9-4D8E-44DB-961A-D7C279B2CA2B}.Test|Any CPU.ActiveCfg = Test|Any CPU
 		{E9B48BE9-4D8E-44DB-961A-D7C279B2CA2B}.Debug Run Client|Any CPU.ActiveCfg = Debug|Any CPU
 		{E9B48BE9-4D8E-44DB-961A-D7C279B2CA2B}.Debug Run Client|Any CPU.Build.0 = Debug|Any CPU
@@ -65,6 +67,8 @@ Global
 		{E9B48BE9-4D8E-44DB-961A-D7C279B2CA2B}.Debug Run Server|Any CPU.Build.0 = Debug|Any CPU
 		{E9B48BE9-4D8E-44DB-961A-D7C279B2CA2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E9B48BE9-4D8E-44DB-961A-D7C279B2CA2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9B48BE9-4D8E-44DB-961A-D7C279B2CA2B}.Release Run Server|Any CPU.ActiveCfg = Release|Any CPU
+		{E9B48BE9-4D8E-44DB-961A-D7C279B2CA2B}.Release Run Server|Any CPU.Build.0 = Release|Any CPU
 		{675D2FE5-2041-4458-B4C0-B907447605D3}.Test|Any CPU.ActiveCfg = Test|Any CPU
 		{675D2FE5-2041-4458-B4C0-B907447605D3}.Test|Any CPU.Build.0 = Test|Any CPU
 		{675D2FE5-2041-4458-B4C0-B907447605D3}.Debug|Any CPU.ActiveCfg = Test|Any CPU
@@ -124,13 +128,12 @@ Global
 		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Test|Any CPU.Build.0 = Debug|Any CPU
 		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Debug Run Client|Any CPU.ActiveCfg = Debug|Any CPU
 		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Debug Run Server|Any CPU.ActiveCfg = Debug|Any CPU
-		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Release Run Server|Any CPU.ActiveCfg = Debug|Any CPU
-		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Release Run Server|Any CPU.Build.0 = Debug|Any CPU
 		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Release Run ClientServer|Any CPU.ActiveCfg = Debug|Any CPU
 		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Debug Run ClientServer|Any CPU.ActiveCfg = Debug|Any CPU
 		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Release Archive|Any CPU.ActiveCfg = Release Archive|Any CPU
 		{421BAEA4-F86F-408F-BE78-97DB762A121E}.ReleaseBETA Archive|Any CPU.ActiveCfg = Release|Any CPU
 		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Release Run Client|Any CPU.ActiveCfg = Release|Any CPU
+		{421BAEA4-F86F-408F-BE78-97DB762A121E}.Release Run Server|Any CPU.ActiveCfg = Release|Any CPU
 		{312A7511-FB7C-4ACE-A46D-16E9CA56A076}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{312A7511-FB7C-4ACE-A46D-16E9CA56A076}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{312A7511-FB7C-4ACE-A46D-16E9CA56A076}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -162,8 +165,6 @@ Global
 		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Debug Run Client|Any CPU.Build.0 = Debug|Any CPU
 		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Debug Run Server|Any CPU.ActiveCfg = Debug|Any CPU
 		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Debug Run Server|Any CPU.Build.0 = Debug|Any CPU
-		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Release Run Server|Any CPU.ActiveCfg = Debug|Any CPU
-		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Release Run Server|Any CPU.Build.0 = Debug|Any CPU
 		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Release Run Client|Any CPU.ActiveCfg = Debug|Any CPU
 		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Release Run Client|Any CPU.Build.0 = Debug|Any CPU
 		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Release Run ClientServer|Any CPU.ActiveCfg = Debug|Any CPU
@@ -174,6 +175,8 @@ Global
 		{10B24D55-0341-4EAF-92D6-C14F121180F1}.ReleaseBETA Archive|Any CPU.Build.0 = Debug|Any CPU
 		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Release Archive|Any CPU.ActiveCfg = Release|Any CPU
+		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Release Run Server|Any CPU.ActiveCfg = Release|Any CPU
+		{10B24D55-0341-4EAF-92D6-C14F121180F1}.Release Run Server|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/HoverFadeText.cs
+++ b/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/HoverFadeText.cs
@@ -23,7 +23,7 @@
       private static readonly Color messageColor = new(249f, 224f, 0f, 255f);
       public string currentText = "";
       public bool canUpdate = true;
-      public Coroutine UpdateTextCoroutine;
+      private Coroutine? UpdateTextCoroutine;
 
       public static HoverFadeText CreateHoverFadeText(Transform? parent = null)
       {
@@ -99,8 +99,6 @@
             UpdateTextCoroutine = null;
             yield break;
           }
-
-          Show();
 
           if (hideTextTimer != 0f)
             timePassedSinceStateUpdate += Time.fixedDeltaTime;

--- a/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/SwivelComponent.cs
+++ b/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/SwivelComponent.cs
@@ -98,7 +98,6 @@ namespace ValheimVehicles.SharedScripts
     public Vector3 targetMovementPosition;
     public Quaternion targetRotation;
 
-    public MotionState CurrentMotionState => currentMotionState;
     public HingeAxis HingeAxes => hingeAxes;
     public Vector3 MaxEuler => maxRotationEuler;
 
@@ -108,6 +107,7 @@ namespace ValheimVehicles.SharedScripts
     private bool isFrozen;
     public virtual int SwivelPersistentId { get; set; }
 
+    public float currentMovementLerp = 0f;
 
     // Update debouncing logic
     public float _lastUpdatedMotionTime = 0f;
@@ -172,7 +172,7 @@ namespace ValheimVehicles.SharedScripts
     protected virtual Quaternion GetCurrentTargetRotation()
     {
       return mode == SwivelMode.Rotate
-        ? CalculateRotationTarget()
+        ? CalculateRotationTarget(1)
         : Quaternion.identity;
     }
 
@@ -249,17 +249,18 @@ namespace ValheimVehicles.SharedScripts
       // Modes that bail early.
       if (mode == SwivelMode.Rotate && currentMotionState == MotionState.AtTarget)
       {
-        animatedTransform.localRotation = CalculateRotationTarget();
-        return;
-      }
-      if (mode == SwivelMode.Move && currentMotionState == MotionState.AtTarget)
-      {
-        animatedTransform.localPosition = startLocalPosition + movementOffset;
+        animatedTransform.localRotation = CalculateRotationTarget(1f);
         return;
       }
       if (mode == SwivelMode.Rotate && currentMotionState == MotionState.AtStart)
       {
-        animatedTransform.localRotation = Quaternion.identity;
+        animatedTransform.localRotation = CalculateRotationTarget(0f);
+        return;
+      }
+
+      if (mode == SwivelMode.Move && currentMotionState == MotionState.AtTarget)
+      {
+        animatedTransform.localPosition = startLocalPosition + movementOffset;
         return;
       }
       if (mode == SwivelMode.Move && currentMotionState == MotionState.AtStart)
@@ -275,7 +276,7 @@ namespace ValheimVehicles.SharedScripts
       switch (mode)
       {
         case SwivelMode.Rotate:
-          targetRotation = CalculateRotationTarget();
+          targetRotation = CalculateRotationTarget(MotionState == MotionState.ToTarget ? 1 : 0);
           var currentRot = animatedTransform.localRotation;
           var maxAnglePerStep = computedInterpolationSpeed * Time.fixedDeltaTime;
           var interpolatedRot = Quaternion.RotateTowards(currentRot, targetRotation, maxAnglePerStep);
@@ -386,20 +387,16 @@ namespace ValheimVehicles.SharedScripts
         snappoint.position = connectorContainer.position;
     }
 
-    public Quaternion CalculateRotationTarget()
+    public Quaternion CalculateRotationTarget(float lerp)
     {
-      hingeEndEuler = Vector3.zero;
-
+      var hingeEndEuler = Vector3.zero;
       if ((hingeAxes & HingeAxis.X) != 0)
         hingeEndEuler.x = (xHingeDirection == HingeDirection.Forward ? 1f : -1f) * maxRotationEuler.x;
       if ((hingeAxes & HingeAxis.Y) != 0)
         hingeEndEuler.y = (yHingeDirection == HingeDirection.Forward ? 1f : -1f) * maxRotationEuler.y;
       if ((hingeAxes & HingeAxis.Z) != 0)
         hingeEndEuler.z = (zHingeDirection == HingeDirection.Forward ? 1f : -1f) * maxRotationEuler.z;
-
-      var target = currentMotionState == MotionState.ToStart ? 0f : 1f;
-      hingeLerpProgress = Mathf.MoveTowards(hingeLerpProgress, target, computedInterpolationSpeed * Time.fixedDeltaTime);
-      return Quaternion.Euler(Vector3.Lerp(Vector3.zero, hingeEndEuler, hingeLerpProgress));
+      return Quaternion.Euler(Vector3.Lerp(Vector3.zero, hingeEndEuler, lerp));
     }
 
     private Quaternion CalculateTargetNearestEnemyRotation()
@@ -596,7 +593,7 @@ namespace ValheimVehicles.SharedScripts
       set => SetMovementOffset(value);
     }
 
-    public MotionState MotionState
+    public virtual MotionState MotionState
     {
       get => currentMotionState;
       set => SetMotionState(value);

--- a/src/ValheimRAFT/README.md
+++ b/src/ValheimRAFT/README.md
@@ -2,63 +2,21 @@
 
 <img src="https://raw.githubusercontent.com/zolantris/ValheimMods/main/src/Thunderstore/icon.png" alt="ValheimRAFT Community Made Boat Hjalmere">
 
+
 This mod aims to continue support for Water based features of the original
 ValheimRAFT mod and incorporate more vehicle types, items, and mechanics within
 the mod
 and further extends its capabilities.
 
-## V3.0.0 Changes
-
-### Land Vehicles can now be built.
-
-They will be absolutely fun to use. But are unbalanced in energy and power and
-really should require rams to be enabled (but you can toggle them off).
-
-- vehicles have a bit of trouble going up mountains. But you can turn and slowly
-  move up the mountain.
-- Losing momentum can cause the vehicle to go the opposite way. Use the break or
-  keep energy going on inclines
-- There is no balance for energy / propulsion. This will be coming in another
-  update.
-- Land Vehicles can wreck forests and mine rocks. Their damage is configurable
-  through `Ram Vehicles` sections. Highly recommended to keep damage high for
-  vehicles to allow them to move.
-    - Later we can consider adding balance to damage breaking parts of the
-      vehicles and costing energy to demolish areas.
-
-### Adds hauling/towing - vikings can now lift their rafts and move them
-
-- Costs stamina and then health until it snaps.
-- Configurable to only cost stamina then snap.
-- Stamina cost is configurable.
-- Dragging vehicles will trigger ram damage. You can turn this off.
-
-### Breaking Changes
-
-- Many ValheimRAFT prefabs have been moved. Break the misplaced prefabs and
-  replace them correctly.
-
-### Other fixes
-
-- **Carts can be added on vehicles**
-- **Stability of vehicles drastically improved**. See "CenterOfMass" percentage
-  allowing you to move the center up to 50% lower than the vehicle's lowest
-  point. Or at 50% exactly at it's lowest Y point.
-- Bounds and rendering are exact. No issues with bound ever again (unless a mod
-  adds a massive collider).
-- Improved ram collisions. There is now a filter for repeated hits to ensure
-  that velocity is over a threshold other to not do a hit.
-- Improved logic to protect player when teleporting. There is a collision check
-  when the ram attempt to hit a player so it does not hit the player if they are
-  currently teleporting.
-- MapSync should have 0 Null reference errors. But this logic will continue to
-  be improved/optimize.
-
-------
-
 This mod has both a beta and a non-beta on Thunderstore. Please make sure you
 are using non-beta if you want a stable experience. If you want to test
 previews, swap to the beta variant.
+
+## Tutorial
+
+This document contains tutorials on configuring the mod.
+
+## Mod Info
 
 :warning: Warning. If you are reading this readme on the
 [ValheimMods/ValheimRAFT](https://github.com/zolantris/ValheimMods/tree/main/src/ValheimRAFT)
@@ -563,7 +521,7 @@ This logging has yet to be implemented.
 
 ---
 
-## 🏗️ Core Components
+## Core Components
 
 <table>
   <tr>
@@ -607,35 +565,60 @@ This logging has yet to be implemented.
 
 ## 🚀 Getting Started
 
-### 1. Build an Engine
+### 1. Build a power source
+
+Current prefabs: `Eitr Source`
 
 - Place a **Power Engine** on your raft or base.
 - Add valid fuel (check the tooltip).
-- Start the engine to generate power.
+- Power sources
 
 ### 2. Add Power Storage
 
-- Place a **Battery** nearby or connected via pylons.
+Current prefabs `Eitr Storage`
+
+- Place a **Battery** nearby or connected via pylons for longer distances.
 - Batteries store excess energy and help during low-fuel periods.
+- Batteries will visually fill. Each can be inspected for energy and capacity.
+- Batteries will charge a single battery before charging other batteries in
+  order amount of charge. Highest charge will always charge first.
 
 ### 3. Link With Pylons
 
-- Place **Power Pylons** to extend your network.
+- Place **Power Pylons** to extend your network. Pylons are only needed when
+  linking devices across long distances.
 - Pylons will auto-link if within range—no cables required!
+- Pylons will show electricity and connections.
 
 ### 4. Power Consumers
 
-- Attach devices (motors, winches, automation modules) to your power network.
-- They will draw power automatically when the network is supplied.
+Current prefabs: `swivel`
+
+- Place a swivel.
+- Configure a switch to target the swivel. (see mechanism switch section).
+- Provided there is power network and power charge. Clicking activate should
+  rotate or move the swivel.
+
+### Mechanism Switch
+
+The main controller for all mechanisms. Allows for configuring all mechanisms
+available in this mod.
+
+- Can open vehicle debug menu by default without any commands.
+- Can open up a swivel toggle menu
+- Can be configured to activate any single swivel within a reasonable distance (
+  50 meters). The swivel must be in a powered area.
+- Does not directly require power but swivels by default will require power to
+  activate.
 
 ---
 
-## 🧪 Example: Basic Power Network
+## Power Network Diagrams
 
 ```mermaid
 graph LR
   Engine["Engine 🔥"] -- Power --> Battery["Battery 🔋"]
-  Battery -- Power --> Consumer["Winch ⚙️"]
-  Engine -- Power --> Consumer
-  Battery -- Power --> Pylon["Pylon 🔗"]
-  Pylon -- Power --> Consumer2["Lamp 💡"]
+  Battery -- Power --> Consumer["Swivel ⚙️"]
+  ConduitInput["Conduit (Drain)"] -- Eitr/To Power --> Battery["Battery 🔋"]
+  Battery["Battery 🔋"] --> ConduitOutput["Conduit (Charge)"] -- Eitr --> Player
+```

--- a/src/ValheimRAFT/ValheimRAFT.csproj
+++ b/src/ValheimRAFT/ValheimRAFT.csproj
@@ -15,7 +15,7 @@
         <RootNamespace>ValheimRAFT</RootNamespace>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-        <Configurations>Debug;Release;Release Archive;Debug Run ClientServer;Debug Run Client;ReleaseBETA Archive;Debug Run Server</Configurations>
+        <Configurations>Debug;Release;Release Archive;Debug Run ClientServer;Debug Run Client;ReleaseBETA Archive;Debug Run Server;Release Run Server</Configurations>
     </PropertyGroup>
     <Import Project="..\..\base.targets"/>
     <Import Project="..\..\valheim.targets"/>

--- a/src/ValheimVehicles/ValheimVehicles.BepInExConfig/PropulsionConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.BepInExConfig/PropulsionConfig.cs
@@ -30,17 +30,12 @@ public class PropulsionConfig : BepInExBaseConfig<PropulsionConfig>
   // landvehicle turning
   public static ConfigEntry<float> VehicleLandTurnSpeed = null!;
 
-  public static ConfigEntry<bool> AllowCustomRudderSpeeds { get; private set; } =
-    null!;
-
   public static ConfigEntry<float> BallastClimbingOffset { get; private set; } =
     null!;
   public static ConfigEntry<float> SailingMassPercentageFactor { get; set; }
   public static ConfigEntry<bool> AllowFlight { get; set; }
 
   // Propulsion Configs
-  public static ConfigEntry<bool> EnableCustomPropulsionConfig { get; set; }
-
   public static ConfigEntry<float> MaxSailSpeed { get; set; }
   public static ConfigEntry<float> SpeedCapMultiplier { get; set; }
 
@@ -209,11 +204,6 @@ public class PropulsionConfig : BepInExBaseConfig<PropulsionConfig>
 
     // rudder
 
-    EnableCustomPropulsionConfig = config.BindUnique(GenericSectionName,
-      "EnableCustomPropulsionConfig", SailAreaForce.HasPropulsionConfigOverride,
-      ConfigHelpers.CreateConfigDescription("Enables all custom propulsion values", true,
-        true));
-
     SailCustomAreaTier1Multiplier = config.BindUnique(GenericSectionName,
       "SailCustomAreaTier1Multiplier",
       SailAreaForce.CustomTier1AreaForceMultiplier,
@@ -252,12 +242,6 @@ public class PropulsionConfig : BepInExBaseConfig<PropulsionConfig>
       false,
       ConfigHelpers.CreateConfigDescription("Flight allows for different rudder speeds. Use rudder speed only. Do not use sail speed."));
 
-    AllowCustomRudderSpeeds = config.BindUnique(GenericSectionName,
-      "AllowCustomRudderSpeeds", true,
-      ConfigHelpers.CreateConfigDescription(
-        "Allow the raft to use custom rudder speeds set by the player, these speeds are applied alongside sails at half and full speed. See advanced section for the actual speed settings.",
-        true));
-
     WheelDeadZone = config.BindUnique(GenericSectionName,
       "WheelDeadZone",
       0.02f,
@@ -279,21 +263,21 @@ public class PropulsionConfig : BepInExBaseConfig<PropulsionConfig>
   public static void CreateSpeedConfig(ConfigFile config)
   {
     VehicleRudderSpeedBack = config.BindUnique(PropulsionSpeedSection, "Rudder Back Speed",
-      1f,
+      5f,
       ConfigHelpers.CreateConfigDescription(
-        "Set the Back speed of rudder, this will apply with sails", true));
+        "Set the Back speed of rudder, this will not apply sail speed.", true, false, new AcceptableValueRange<float>(2f, 20f)));
     VehicleRudderSpeedSlow = config.BindUnique(PropulsionSpeedSection, "Rudder Slow Speed",
-      1f,
+      5f,
       ConfigHelpers.CreateConfigDescription(
-        "Set the Slow speed of rudder, this will apply with sails", true));
+        "Set the Slow speed of rudder, this will not apply sail speed.", true, false, new AcceptableValueRange<float>(2f, 20f)));
     VehicleRudderSpeedHalf = config.BindUnique(PropulsionSpeedSection, "Rudder Half Speed",
       0f,
       ConfigHelpers.CreateConfigDescription(
-        "Set the Half speed of rudder, this will apply with sails", true));
+        "Set the Half speed of rudder, this will apply additively with sails", true, false, new AcceptableValueRange<float>(0f, 100f)));
     VehicleRudderSpeedFull = config.BindUnique(PropulsionSpeedSection, "Rudder Full Speed",
       0f,
       ConfigHelpers.CreateConfigDescription(
-        "Set the Full speed of rudder, this will apply with sails", true));
+        "Set the Full speed of rudder, this will apply additively with sails", true, false, new AcceptableValueRange<float>(0f, 100f)));
 
     VehicleLandSpeedBack = config.BindUnique(PropulsionSpeedSection, "LandVehicle Back Speed", 1f,
       ConfigHelpers.CreateConfigDescription(

--- a/src/ValheimVehicles/ValheimVehicles.Components/MechanismSwitch.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Components/MechanismSwitch.cs
@@ -37,7 +37,8 @@ public class MechanismSwitch : AnimatedLeverMechanism, IAnimatorHandler, Interac
   }
   public List<SwivelComponent> nearbySwivelComponents = new();
   public MechanismSwitchConfigSync prefabConfigSync = new();
-  public MechanismSwitchCustomConfig Config => prefabConfigSync.Config;
+  public bool hasInitPrefabConfigSync = false;
+  public MechanismSwitchCustomConfig Config => this.GetOrCache<MechanismSwitchConfigSync>(ref prefabConfigSync, ref hasInitPrefabConfigSync).Config;
   public static Vector3 detachOffset = new(0f, 0.5f, 0f);
 
   public SwivelComponent? TargetSwivel
@@ -77,12 +78,8 @@ public class MechanismSwitch : AnimatedLeverMechanism, IAnimatorHandler, Interac
 
   public MechanismAction SelectedAction
   {
-    get => _selectedMechanismAction;
-    set
-    {
-      _selectedMechanismAction = value;
-      OnMechanismActionUpdate(_selectedMechanismAction);
-    }
+    get => Config.SelectedAction;
+    set => Config.SelectedAction = value;
   }
 
   public List<SwivelComponent> GetNearestSwivels()
@@ -237,24 +234,6 @@ public class MechanismSwitch : AnimatedLeverMechanism, IAnimatorHandler, Interac
   public void SetMechanismAction(MechanismAction action)
   {
     prefabConfigSync.Request_SetSelectedAction(action);
-  }
-
-  /// <summary>
-  /// for side-effects and hooks
-  /// </summary>
-  /// todo we may not want to keep this
-  public void OnMechanismActionUpdate(MechanismAction action)
-  {
-    if (!CanFireMechanismActionSideEffects) return;
-
-    try
-    {
-      // do stuff.
-    }
-    catch (Exception e)
-    {
-      CanFireMechanismActionSideEffects = false;
-    }
   }
 
   /// <summary>

--- a/src/ValheimVehicles/ValheimVehicles.Components/PrefabConfigSync.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Components/PrefabConfigSync.cs
@@ -11,7 +11,6 @@ using ValheimVehicles.ValheimVehicles.RPC;
 
 namespace ValheimVehicles.Components;
 
-[RequireComponent(typeof(ZNetView))]
 public class PrefabConfigSync<T, TComponentInterface> : MonoBehaviour, IPrefabCustomConfigRPCSync<T> where T : ISerializableConfig<T, TComponentInterface>, new()
 {
   public ZNetView? m_nview { get; set; }

--- a/src/ValheimVehicles/ValheimVehicles.Controllers/VehicleMovementController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Controllers/VehicleMovementController.cs
@@ -889,12 +889,6 @@
     /// <returns></returns>
     private float GetRudderForcePerSpeed()
     {
-      if (!PropulsionConfig.AllowCustomRudderSpeeds.Value)
-      {
-        _rudderForce = 1f;
-        return _rudderForce;
-      }
-
       switch (VehicleSpeed)
       {
         case Ship.Speed.Stop:
@@ -2920,8 +2914,8 @@
                                    (m_stearForce * (0f - m_rudderValue) *
                                     directionMultiplier);
 
-      if (PropulsionConfig.AllowCustomRudderSpeeds.Value)
-        shipAdditiveSteerForce *= Mathf.Clamp(_rudderForce, 1f, 10f);
+      // additional speeded to the vehicle.
+      shipAdditiveSteerForce *= Mathf.Clamp(_rudderForce, 1f, 10f);
 
       // Adds additional speeds to turning
       if (PiecesController?.m_rudderPieces.Count > 0)
@@ -3028,12 +3022,8 @@
         VehicleSpeed != Ship.Speed.Back ? 1 : -1;
       steerForce *= directionMultiplier;
 
-      // todo see if this is necessary. This logic is from the Base game Ship
-
-      if (PropulsionConfig.AllowCustomRudderSpeeds.Value)
-        steerForce += GetAdditiveSteerForce(directionMultiplier);
-      else if (VehicleSpeed is Ship.Speed.Back or Ship.Speed.Slow)
-        steerForce += GetAdditiveSteerForce(directionMultiplier);
+      // additional speed added to the vehicle
+      steerForce += GetAdditiveSteerForce(directionMultiplier);
 
       switch (flying)
       {

--- a/src/ValheimVehicles/ValheimVehicles.Integrations.PowerSystem/PowerSystemRegistry.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Integrations.PowerSystem/PowerSystemRegistry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using UnityEngine;
 using ValheimVehicles.Helpers;
@@ -119,25 +120,34 @@ public static class PowerSystemRegistry
 
   public static bool ContainsZDO(ZDO zdo)
   {
+    if (zdo == null) return false;
     return _byZdo.ContainsKey(zdo);
   }
 
-  public static bool TryGetByZdo(ZDO zdo, out PowerNetworkData data)
+  public static bool TryGetByZdo(ZDO? zdo, [NotNullWhen(true)] out PowerNetworkData? data)
   {
+    data = null;
+    if (zdo == null) return false;
     return _byZdo.TryGetValue(zdo, out data);
   }
-  public static bool TryGetByZdoid(ZDOID zdoid, out PowerNetworkData data)
+  public static bool TryGetByZdoid(ZDOID? zdoid, [NotNullWhen(true)] out PowerNetworkData? data)
   {
-    return _byZdoid.TryGetValue(zdoid, out data);
+    data = null;
+    if (zdoid == null) return false;
+    return _byZdoid.TryGetValue(zdoid.Value, out data);
   }
-  public static bool TryGetByData(PowerSystemComputeData data, out PowerNetworkData pnd)
+  public static bool TryGetByData(PowerSystemComputeData? data, [NotNullWhen(true)] out PowerNetworkData? pnd)
   {
+    pnd = null;
+    if (data == null) return false;
     return _byData.TryGetValue(data, out pnd);
   }
 
   // (Optional) TryGet with type constraint for Data
-  public static bool TryGetData<T>(ZDO zdo, out T typedData) where T : PowerSystemComputeData
+  public static bool TryGetData<T>(ZDO? zdo, [NotNullWhen(true)] out T? typedData) where T : PowerSystemComputeData
   {
+    typedData = null;
+    if (zdo == null) return false;
     if (TryGetByZdo(zdo, out var pnd) && pnd.Data is T t)
     {
       typedData = t;

--- a/src/ValheimVehicles/ValheimVehicles.Integrations/MechanismSelectorPanelIntegration.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Integrations/MechanismSelectorPanelIntegration.cs
@@ -38,6 +38,10 @@ public class MechanismSelectorPanelIntegration : MechanismSelectorPanel
     // We do not let local overrides of this readonly value.
     var saveConfig = new MechanismSwitchCustomConfig();
     saveConfig.ApplyFrom(_currentPanelConfig);
+    mechanismSwitch.SelectedAction = _currentPanelConfig.SelectedAction;
+    mechanismSwitch.TargetSwivelId = _currentPanelConfig.TargetSwivelId;
+    mechanismSwitch.TargetSwivel = _currentPanelConfig.TargetSwivel ?? MechanismSwitchCustomConfig.ResolveSwivel(_currentPanelConfig.TargetSwivelId);
+
     mechanismSwitch.prefabConfigSync.Request_CommitConfigChange(saveConfig);
   }
 

--- a/src/ValheimVehicles/ValheimVehicles.Integrations/MechanismSwitchCustomConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Integrations/MechanismSwitchCustomConfig.cs
@@ -14,6 +14,7 @@ namespace ValheimVehicles.SharedScripts
   {
     public MechanismAction SelectedAction = MechanismAction.None;
     public int TargetSwivelId = 0;
+    public SwivelComponent? TargetSwivel;
     public MechanismSwitchCustomConfig Config => this;
 
     public void ApplyFrom(IMechanismSwitchConfig component)
@@ -22,6 +23,7 @@ namespace ValheimVehicles.SharedScripts
       TargetSwivelId = component.TargetSwivel != null && component.TargetSwivel.TryGetComponent(out ZNetView view) && view.GetZDO() != null
         ? ZdoWatchController.Instance.GetOrCreatePersistentID(view.GetZDO())
         : 0;
+      TargetSwivel = ResolveSwivel(component.TargetSwivelId);
     }
 
     public int GetStableHashCode()

--- a/src/ValheimVehicles/ValheimVehicles.Integrations/SwivelComponentBridge.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Integrations/SwivelComponentBridge.cs
@@ -365,7 +365,7 @@
       zdo.Set(VehicleZdoVars.SwivelParentId, persistentId);
 
       m_hoverFadeText.Show();
-      m_hoverFadeText.transform.position = transform.position + Vector3.up;
+      m_hoverFadeText.transform.position = transform.position + Vector3.up * 2f;
       m_hoverFadeText.currentText = ModTranslations.Swivel_Connected;
 
       // must call this otherwise everything is in world position. 
@@ -577,18 +577,18 @@
         return;
       }
 
-      powerConsumerIntegration.Data.Load();
-
-      var isOwner = netView.IsOwner();
-      if (!isOwner || !powerConsumerIntegration)
-      {
-        // possible infinity update here...
-        PowerSystemRPC.Request_UpdatePowerConsumer(netView.GetZDO().m_uid, swivelPowerConsumer.Data);
-      }
-      else
-      {
-        powerConsumerIntegration.UpdateNetworkedData();
-      }
+      // powerConsumerIntegration.Data.Load();
+      //
+      // var isOwner = netView.IsOwner();
+      // if (!isOwner || !powerConsumerIntegration)
+      // {
+      //   // possible infinity update here...
+      //   PowerSystemRPC.Request_UpdatePowerConsumer(netView.GetZDO().m_uid, swivelPowerConsumer.Data);
+      // }
+      // else
+      // {
+      //   powerConsumerIntegration.UpdateNetworkedData();
+      // }
     }
 
     public void OnInitComplete()

--- a/src/ValheimVehicles/ValheimVehicles.Integrations/SwivelCustomConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Integrations/SwivelCustomConfig.cs
@@ -324,13 +324,25 @@ namespace ValheimVehicles.BepInExConfig
       set;
     }
 
+    public static MotionState GetCompleteMotionState(MotionState current)
+    {
+      return current switch
+      {
+        MotionState.AtStart => MotionState.AtStart,
+        MotionState.AtTarget => MotionState.AtTarget,
+        MotionState.ToStart => MotionState.AtStart,
+        MotionState.ToTarget => MotionState.AtTarget,
+        _ => MotionState.AtStart
+      };
+    }
+
     public static MotionState GetNextMotionState(MotionState current)
     {
       return current switch
       {
         MotionState.AtStart => MotionState.ToTarget,
-        MotionState.ToStart => MotionState.ToTarget,
         MotionState.AtTarget => MotionState.ToStart,
+        MotionState.ToStart => MotionState.ToTarget,
         MotionState.ToTarget => MotionState.ToStart,
         _ => MotionState.AtStart
       };

--- a/src/ValheimVehicles/ValheimVehicles.Prefabs/ValheimVehicles.Prefabs.Registry/MechanismPrefabs.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Prefabs/ValheimVehicles.Prefabs.Registry/MechanismPrefabs.cs
@@ -60,8 +60,6 @@ public class MechanismPrefabs : RegisterPrefab<MechanismPrefabs>
         }
       ]
     }));
-    RegisterModifiedPrefab(prefab);
-
   }
 
   private void RegisterPowerSourceEitr()
@@ -115,7 +113,6 @@ public class MechanismPrefabs : RegisterPrefab<MechanismPrefabs>
         }
       ]
     }));
-    RegisterModifiedPrefab(prefab);
   }
 
   private void RegisterPowerChargePlate()
@@ -157,7 +154,6 @@ public class MechanismPrefabs : RegisterPrefab<MechanismPrefabs>
         }
       ]
     }));
-    RegisterModifiedPrefab(prefab);
   }
 
   private void RegisterPowerDrainPlate()
@@ -200,7 +196,6 @@ public class MechanismPrefabs : RegisterPrefab<MechanismPrefabs>
         }
       ]
     }));
-    RegisterModifiedPrefab(prefab);
   }
 
   // private void RegisterCoalEngine()
@@ -299,7 +294,6 @@ public class MechanismPrefabs : RegisterPrefab<MechanismPrefabs>
         }
       ]
     }));
-    RegisterModifiedPrefab(prefab);
   }
 
 
@@ -342,19 +336,6 @@ public class MechanismPrefabs : RegisterPrefab<MechanismPrefabs>
         }
       ]
     }));
-    RegisterModifiedPrefab(prefab);
-  }
-
-  public static void RegisterModifiedPrefab(GameObject prefab)
-  {
-    if (ZNetScene.instance != null)
-    {
-      ZNetScene.instance.m_namedPrefabs[prefab.name.GetStableHashCode()] = prefab;
-    }
-    else
-    {
-      Jotunn.Logger.LogWarning($"ZNetScene is not initialized. Could not register {prefab.name}.");
-    }
   }
 
   public override void OnRegister()

--- a/src/ValheimVehicles/ValheimVehicles.Prefabs/ValheimVehicles.Prefabs.Registry/VehiclePrefabs.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Prefabs/ValheimVehicles.Prefabs.Registry/VehiclePrefabs.cs
@@ -65,6 +65,11 @@
       PrefabRegistryHelpers.SetWearNTearSupport(wnt,
         WearNTear.MaterialType.HardWood);
 
+      // no ash damage
+      wnt.m_ashDamageImmune = true;
+      wnt.m_ashDamageResist = true;
+      // no fire damage
+      wnt.m_burnable = false;
       wnt.m_onDestroyed += woodWnt.m_onDestroyed;
       // triggerPrivateArea will damage enemies/pieces when within it
       wnt.m_triggerPrivateArea = true;
@@ -96,7 +101,6 @@
       wnt.m_onDestroyed += woodWnt.m_onDestroyed;
       // triggerPrivateArea will damage enemies/pieces when within it
       wnt.m_triggerPrivateArea = true;
-
       wnt.m_supports = true;
       wnt.m_support = 2000f;
       wnt.m_noSupportWear = true;
@@ -147,7 +151,7 @@
       var piece =
         PrefabRegistryHelpers.AddPieceForPrefab(PrefabNames.LandVehicle,
           landVehiclePrefab);
-      piece.m_primaryTarget = true;
+      piece.m_primaryTarget = false;
       piece.m_randomTarget = true;
       piece.m_targetNonPlayerBuilt = true;
       piece.m_waterPiece = false;

--- a/src/ValheimVehicles/ValheimVehicles.RPC/RPCUtils.cs
+++ b/src/ValheimVehicles/ValheimVehicles.RPC/RPCUtils.cs
@@ -109,10 +109,14 @@ public static class RPCUtils
 
 
   /// <summary>
-  /// Runs if nearby. Requires the callback method to fire RPC to the peer.
+  /// Runs if nearby. Requires the callback method to fire RPC to the peer or local player.
   /// </summary>
   public static void RunIfNearby(ZDO zdo, float threshold, Action<long> action)
   {
+    if (ZNet.instance && Player.m_localPlayer && Vector3.Distance(zdo.GetPosition(), ZNet.instance.m_referencePosition) < threshold)
+    {
+      action(Player.m_localPlayer.GetOwner());
+    }
     if (!TryGetNearbyPeers(zdo, threshold, out var matchingPeers)) return;
     matchingPeers.ForEach(x =>
     {

--- a/src/ValheimVehicles/ValheimVehicles.RPC/RPCUtils.cs
+++ b/src/ValheimVehicles/ValheimVehicles.RPC/RPCUtils.cs
@@ -114,6 +114,10 @@ public static class RPCUtils
   public static void RunIfNearby(ZDO zdo, float threshold, Action<long> action)
   {
     if (!TryGetNearbyPeers(zdo, threshold, out var matchingPeers)) return;
-    matchingPeers.ForEach(x => action(x.m_uid));
+    matchingPeers.ForEach(x =>
+    {
+      if (x == null) return;
+      action(x.m_uid);
+    });
   }
 }

--- a/src/ValheimVehicles/ValheimVehicles.RPC/SwivelPrefabConfigRPC.cs
+++ b/src/ValheimVehicles/ValheimVehicles.RPC/SwivelPrefabConfigRPC.cs
@@ -171,7 +171,7 @@ public class SwivelPrefabConfigRPC
       yield break;
     }
 
-    swivelComponentBridge.SetMotionUpdate(motionUpdate, true);
+    swivelComponentBridge.SetAuthoritativeMotion(motionUpdate, true);
     yield return false;
   }
 
@@ -190,7 +190,7 @@ public class SwivelPrefabConfigRPC
     var hasLocalInstance = SwivelComponentBridge.ZdoToComponent.TryGetValue(zdo, out var swivelComponentBridge);
     if (hasLocalInstance && swivelComponentBridge != null)
     {
-      swivelComponentBridge.SetMotionUpdate(new SwivelMotionUpdate
+      swivelComponentBridge.SetAuthoritativeMotion(new SwivelMotionUpdate
       {
         MotionState = completedMotionState,
         StartTime = 0f,

--- a/valheim.targets
+++ b/valheim.targets
@@ -433,21 +433,21 @@
         <Exec Condition="Exists('$(AssetsDir)Translations\English\')" Command="xcopy /d &quot;$(AssetsDir)Translations\English\&quot; &quot;$(PluginDeployPath)\Assets\Translations\English\&quot; /E/H/Y"/>
     </Target>
     <!--     Condition=" $(AssemblyName) == 'ValheimRAFT' And Exists('$(SandboxiePluginDeployPath)') And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "-->
-    <Target Name="Copy_To_R2ModMan_vm" AfterTargets="Copy_To_R2ModMan" Condition="'$(IsRunnable)' == 'true' and '$(SandBoxieFileExitCode)' == '0'">
-        <!--   Will only run if the above passes     -->
-        <Exec Command="copy &quot;$(SolutionDir)plugins\Newtonsoft.Json.dll&quot; &quot;$(SandboxiePluginDeployPath)\Newtonsoft.Json.dll&quot;"/>
-        <Exec Command="copy &quot;$(SolutionDir)plugins\ServerSync.dll&quot; &quot;$(SandboxiePluginDeployPath)\ServerSync.dll&quot;"/>
+<!--    <Target Name="Copy_To_R2ModMan_vm" AfterTargets="Copy_To_R2ModMan" Condition="'$(IsRunnable)' == 'true' and '$(SandBoxieFileExitCode)' == '0'">-->
+<!--        &lt;!&ndash;   Will only run if the above passes     &ndash;&gt;-->
+<!--        <Exec Command="copy &quot;$(SolutionDir)plugins\Newtonsoft.Json.dll&quot; &quot;$(SandboxiePluginDeployPath)\Newtonsoft.Json.dll&quot;"/>-->
+<!--        <Exec Command="copy &quot;$(SolutionDir)plugins\ServerSync.dll&quot; &quot;$(SandboxiePluginDeployPath)\ServerSync.dll&quot;"/>-->
 
-        <Exec Condition="Exists('$(OutDir)$(AssemblyName).dll')" Command="copy &quot;$(OutDir)$(AssemblyName).dll&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).dll&quot;"/>
-        <Exec Condition="Exists('$(OutDir)$(AssemblyName).pdb')" Command="copy &quot;$(OutDir)$(AssemblyName).pdb&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).pdb&quot;"/>
-        <Exec Condition="Exists('$(OutDir)$(AssemblyName).mdb')" Command="copy &quot;$(OutDir)$(AssemblyName).mdb&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).mdb&quot;"/>
+<!--        <Exec Condition="Exists('$(OutDir)$(AssemblyName).dll')" Command="copy &quot;$(OutDir)$(AssemblyName).dll&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).dll&quot;"/>-->
+<!--        <Exec Condition="Exists('$(OutDir)$(AssemblyName).pdb')" Command="copy &quot;$(OutDir)$(AssemblyName).pdb&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).pdb&quot;"/>-->
+<!--        <Exec Condition="Exists('$(OutDir)$(AssemblyName).mdb')" Command="copy &quot;$(OutDir)$(AssemblyName).mdb&quot; &quot;$(SandboxiePluginDeployPath)\$(AssemblyName).mdb&quot;"/>-->
 
-        <Exec Condition="$(AssemblyName) == 'SentryUnityWrapper'" Command="xcopy &quot;$(SolutionDir)\SentryUnity\1.8.0\runtime&quot; &quot;$(SandboxiePluginDeployPath)\&quot; /q /s /y /i"/>
-        <!--        <Exec Condition="'$(FilesCheckExitCode)' == '0'" Command="xcopy &quot;$(TargetDir)&quot; &quot;$(SandboxiePluginDeployPath)\&quot; /q /s /y /i"/>-->
+<!--        <Exec Condition="$(AssemblyName) == 'SentryUnityWrapper'" Command="xcopy &quot;$(SolutionDir)\SentryUnity\1.8.0\runtime&quot; &quot;$(SandboxiePluginDeployPath)\&quot; /q /s /y /i"/>-->
+<!--        &lt;!&ndash;        <Exec Condition="'$(FilesCheckExitCode)' == '0'" Command="xcopy &quot;$(TargetDir)&quot; &quot;$(SandboxiePluginDeployPath)\&quot; /q /s /y /i"/>&ndash;&gt;-->
 
-        <Exec Condition="Exists('$(AssetsDir)')" Command="xcopy /d &quot;$(AssetsDir)&quot; &quot;$(SandboxiePluginDeployPath)\Assets\&quot; /E/H/Y"/>
-        <Exec Condition="Exists('$(AssetsDir)Translations\English\')" Command="xcopy /d &quot;$(AssetsDir)Translations\English\&quot; &quot;$(SandboxiePluginDeployPath)\Assets\Translations\English\&quot; /E/H/Y"/>
-    </Target>
+<!--        <Exec Condition="Exists('$(AssetsDir)')" Command="xcopy /d &quot;$(AssetsDir)&quot; &quot;$(SandboxiePluginDeployPath)\Assets\&quot; /E/H/Y"/>-->
+<!--        <Exec Condition="Exists('$(AssetsDir)Translations\English\')" Command="xcopy /d &quot;$(AssetsDir)Translations\English\&quot; &quot;$(SandboxiePluginDeployPath)\Assets\Translations\English\&quot; /E/H/Y"/>-->
+<!--    </Target>-->
     <Target Name="Generate_Mod_Archive" AfterTargets="PostBuildEvent" Condition=" '$(Configuration)|$(Platform)' == 'Release Archive|AnyCPU' ">
         <PropertyGroup>
             <RepoDir>$(SolutionDir)src\ValheimRAFT\</RepoDir>


### PR DESCRIPTION
- lerps the server side updates
- fixes infinite loops in single player and server side hybrid
- makes rudder custom speeds at minimum 2m/s and default at 5m/s for slow and reverse speeds.
- removes rudder custom speed. This is no longer a valid config. The rudder speeds can always be set and are always available to change for admins. 