### PR TITLE
Fix/unity 6 ship and air vehicle compatibility

### DIFF
--- a/build/valheimraft_version.props
+++ b/build/valheimraft_version.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup Label="ValheimRAFT Version">
-        <Version>4.0.0</Version>
+        <Version>4.0.1</Version>
         <AssemblyVersion>$(Version).0</AssemblyVersion>
         <FileVersion>$(Version).0</FileVersion>
         <PackageVersion>$(Version)</PackageVersion>

--- a/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/TargetController.cs
+++ b/src/ValheimRAFT.Unity/Assets/ValheimVehicles/SharedScripts/TargetController.cs
@@ -169,7 +169,12 @@ namespace ValheimVehicles.SharedScripts
       if (!gameObject.name.StartsWith(PrefabNames.CannonControlCenter)) return;
       if (transform.root == transform) return;
 
-      if (!m_nview) Destroy(this);
+      if (!m_nview)
+      {
+        Destroy(this);
+        return;
+      }
+
       if (Player.m_localPlayer)
       {
         Player.m_localPlayer.Message(MessageHud.MessageType.Center, Localization.instance.Localize("$valheim_vehicles_cannon_control_center_placement_error"));

--- a/src/ValheimRAFT/Thunderstore/manifest.json
+++ b/src/ValheimRAFT/Thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ValheimRAFT",
-  "version_number": "4.0.0",
+  "version_number": "4.0.1",
   "website_url": "https://github.com/zolantris/ValheimMods/tree/main/src/ValheimRAFT",
   "description": "ValheimRAFT - a vehicles mod for valheim. Build a ship, build a land vehicle. Explore valheim! This is release channel. Features should be released slower and should be more stable. Use the beta channel if you want to see new features sooner.",
   "dependencies": [

--- a/src/ValheimRAFT/ThunderstoreBeta/manifest.json
+++ b/src/ValheimRAFT/ThunderstoreBeta/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ValheimRAFTBETA",
-  "version_number": "4.0.0",
+  "version_number": "4.0.1",
   "website_url": "https://github.com/zolantris/ValheimMods/tree/main/src/ValheimRAFT",
   "description": "ValheimRAFT (BETA) - a vehicles mod for valheim. Build a ship, build a land vehicle (3.0.0). Explore valheim! This is a BETA release channel. Please use the non-beta for stable versions.",
   "dependencies": [

--- a/src/ValheimVehicles/ValheimVehicles.BepInExConfig/PhysicsConfig.cs
+++ b/src/ValheimVehicles/ValheimVehicles.BepInExConfig/PhysicsConfig.cs
@@ -304,11 +304,11 @@ public class PhysicsConfig : BepInExBaseConfig<PhysicsConfig>
         "Sets the absolute max speed a vehicle can ever move in vertical direction. This can significantly reduce vertical sway when lowered. This will limit the ship capability to launch into space. Lower values are safer. Too low and the vehicle will not recover fast from being underwater if falling into the water. Flight vehicles will not be affected by this value.",
         true, false, maxLinearYVelocityAcceptableValues));
 
-    MaxAngularVelocity = config.BindUnique(SectionKey, "MaxVehicleAngularVelocity",
-      5f,
+    MaxAngularVelocity = config.BindUnique(SectionKey, $"MaxVehicleAngularVelocity_{VersionedConfigUtil.GetDynamicMinorVersionKey()}",
+      0.1f,
       ConfigHelpers.CreateConfigDescription(
         "Sets the absolute max speed a vehicle can ROTATE in. Having a high value means the vehicle can spin out of control.",
-        true, false, new AcceptableValueRange<float>(0.1f, 10f)));
+        true, false, new AcceptableValueRange<float>(0.05f, 3f)));
 
     HullFloatationColliderLocation = config.BindUnique(FloatationPhysicsSectionKey,
       "HullFloatationColliderLocation",


### PR DESCRIPTION
Further stability post unity 6.

Fixes
- water vehicles
- sub vehicles
- air vehicles

Excludes
- landvehicles (forward/reverse causes vehicle to pancake)
- wheel turning is pretty sensitive too. 