### PR TITLE
Feat/less jittery zsynctransform

### DIFF
--- a/src/ValheimVehicles/ValheimVehicles.Controllers/PatchController.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Controllers/PatchController.cs
@@ -43,6 +43,7 @@ public static class PatchController
       typeof(Fireplace_WaterPatches),
       typeof(Minimap_VehicleIcons),
       typeof(ZDO_Patch),
+      typeof(ZSyncTransform_Patch),
 #if DEBUG
       typeof(RPCRegistryDebugger_Patches),
       // TODO Migrate to It's own mod

--- a/src/ValheimVehicles/ValheimVehicles.Patches/ZSyncTransform_Patch.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Patches/ZSyncTransform_Patch.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using HarmonyLib;
+using UnityEngine;
+using ValheimVehicles.Controllers;
+
+namespace ValheimVehicles.Patches;
+
+[HarmonyPatch]
+public class ZSyncTransform_Patch
+{
+
+  public static HashSet<ZSyncTransform> ZsyncWithPiecesController = new();
+
+  [HarmonyPatch(typeof(ZSyncTransform), nameof(ZSyncTransform.CustomLateUpdate))]
+  [HarmonyPostfix]
+  private static void CustomLateUpdate(ZSyncTransform __instance)
+  {
+    if (__instance.m_characterParentSync || !__instance.m_nview) return;
+    if (!__instance.m_nview.transform.parent) return;
+    if (!__instance.m_nview.transform.GetComponentInParent<VehiclePiecesController>())
+    {
+      if (ZsyncWithPiecesController.Contains(__instance))
+      {
+        ZsyncWithPiecesController.Remove(__instance);
+        __instance.m_characterParentSync = false;
+      }
+
+      return;
+    }
+
+    // VehiclePiecesController Exists. Ensure m_characterParentSync is enabled
+    ZsyncWithPiecesController.Add(__instance);
+    __instance.m_characterParentSync = true;
+  }
+
+  [HarmonyPatch(typeof(ZSyncTransform), nameof(ZSyncTransform.GetRelativePosition))]
+  [HarmonyPrefix]
+  private static bool GetRelativePosition_ForVehicle(ZSyncTransform __instance, ref bool __result, ZDO zdo, out ZDOID parent, out string attachJoint, out Vector3 relativePos, out Quaternion relativeRot, out Vector3 relativeVel)
+  {
+    parent = ZDOID.None;
+    attachJoint = "";
+    relativePos = Vector3.zero;
+    relativeRot = Quaternion.identity;
+    relativeVel = Vector3.zero;
+
+    var t = __instance.transform;
+    if (!t.parent) return true;
+
+    var vehiclePiece = t.GetComponentInParent<VehiclePiecesController>();
+    if (vehiclePiece && vehiclePiece.m_nview)
+    {
+      parent = vehiclePiece.m_nview.GetZDO().m_uid;
+      relativePos = t.localPosition;
+      relativeRot = t.localRotation;
+      __result = true;
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/ValheimVehicles/ValheimVehicles.Patches/ZSyncTransform_Patch.cs
+++ b/src/ValheimVehicles/ValheimVehicles.Patches/ZSyncTransform_Patch.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using HarmonyLib;
 using UnityEngine;
 using ValheimVehicles.Controllers;
+using Zolantris.Shared;
 
 namespace ValheimVehicles.Patches;
 
@@ -37,24 +38,34 @@ public class ZSyncTransform_Patch
   [HarmonyPrefix]
   private static bool GetRelativePosition_ForVehicle(ZSyncTransform __instance, ref bool __result, ZDO zdo, out ZDOID parent, out string attachJoint, out Vector3 relativePos, out Quaternion relativeRot, out Vector3 relativeVel)
   {
-    parent = ZDOID.None;
-    attachJoint = "";
-    relativePos = Vector3.zero;
-    relativeRot = Quaternion.identity;
-    relativeVel = Vector3.zero;
-
     var t = __instance.transform;
-    if (!t.parent) return true;
+    if (!t.parent)
+    {
+      parent = ZDOID.None;
+      attachJoint = "";
+      relativePos = Vector3.zero;
+      relativeRot = Quaternion.identity;
+      relativeVel = Vector3.zero;
+      return true;
+    }
 
     var vehiclePiece = t.GetComponentInParent<VehiclePiecesController>();
-    if (vehiclePiece && vehiclePiece.m_nview)
+    if (vehiclePiece && vehiclePiece.Manager.m_nview)
     {
-      parent = vehiclePiece.m_nview.GetZDO().m_uid;
+      parent = vehiclePiece.Manager.m_nview.GetZDO().m_uid;
+      attachJoint = "";
+      relativeVel = Vector3.zero;
       relativePos = t.localPosition;
       relativeRot = t.localRotation;
       __result = true;
       return false;
     }
+
+    parent = ZDOID.None;
+    attachJoint = "";
+    relativePos = Vector3.zero;
+    relativeRot = Quaternion.identity;
+    relativeVel = Vector3.zero;
 
     return true;
   }


### PR DESCRIPTION
Not a noticeable difference in jitter when testing with dedicated + 1 main client and 1 client that was a bit more laggy. But it might be a tiny bit better and less risk of velocity changes causing problems.

TODOS

- [ ] Research if increasing update tick for zsynctransform on vehicles can be done safely.
- [ ] Cache component checks for ZSync onboard vehicle so they are not done per physics update.